### PR TITLE
Kubernetes integration for Nelson

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -233,6 +233,7 @@ nelson {
   #
   #     infrastructure {
   #       scheduler {
+  #         scheduler = "nomad"
   #         nomad {
   #           endpoint = "http://nomad.service.texas.your.company.com:1234/"
   #           timeout = 1 second

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -16,28 +16,29 @@
 //: ----------------------------------------------------------------------------
 package nelson
 
-import scalaz.{Order, ValidationNel, ~>}
-import scalaz.std.string._
-import scalaz.syntax.monoid._
-import scalaz.std.set._
-import scalaz.syntax.std.option._
-import scalaz.syntax.foldable._
-import scalaz.concurrent.Task
 import java.net.URI
 import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
 
-import concurrent.duration._
-import helm.ConsulOp
-import health.HealthCheckOp
-import storage.StoreOp
-import scheduler.SchedulerOp
-import Workflow.WorkflowOp
-import docker.DockerOp
-import logging.LoggingOp
-import vault.Vault
-import loadbalancers.LoadbalancerOp
 import com.amazonaws.regions.Region
+import concurrent.duration._
+import health.HealthCheckOp
+import docker.DockerOp
+import helm.ConsulOp
+import loadbalancers.LoadbalancerOp
+import logging.LoggingOp
+import org.http4s.Uri
+import scalaz.concurrent.Task
+import scalaz.std.set._
+import scalaz.std.string._
+import scalaz.syntax.foldable._
+import scalaz.syntax.monoid._
+import scalaz.syntax.std.option._
+import scalaz.{Order, ValidationNel, ~>}
+import scheduler.SchedulerOp
+import storage.StoreOp
+import vault.Vault
+import Workflow.WorkflowOp
 
 
 object Infrastructure {
@@ -61,7 +62,7 @@ object Infrastructure {
   )
 
   final case class Nomad(
-    endpoint: org.http4s.Uri,
+    endpoint: Uri,
     timeout: Duration,
     dockerRepoUser: String,
     dockerRepoPassword: String,
@@ -69,6 +70,11 @@ object Infrastructure {
     loggingImage: Option[docker.Docker.Image],
     mhzPerCPU: Int,
     splunk: Option[SplunkConfig]
+  )
+
+  final case class Kubernetes(
+    endpoint: Uri,
+    timeout: Duration
   )
 
   final case class SplunkConfig(

--- a/core/src/main/scala/KubernetesClient.scala
+++ b/core/src/main/scala/KubernetesClient.scala
@@ -1,0 +1,375 @@
+package nelson
+
+import argonaut._
+import argonaut.Argonaut._
+import journal.Logger
+import org.http4s.AuthScheme
+import org.http4s.Credentials.Token
+import org.http4s.Uri
+import org.http4s.{Method, Request}
+import org.http4s.argonaut._
+import org.http4s.client.Client
+import org.http4s.headers.Authorization
+import scalaz.{Foldable, Monoid}
+import scalaz.concurrent.Task
+import scalaz.Scalaz._
+
+import nelson.Datacenter.StackName
+import nelson.Manifest.{EnvironmentVariable, Plan, Ports, Port}
+import nelson.docker.Docker.Image
+import nelson.health._
+
+/**
+ * A bare bones Kubernetes client used for impelementing a Kubernetes
+ * [[nelson.scheduler.SchedulerOp]] and [[nelson.loadbalancers.LoadBalancerOp]].
+ *
+ * This should really be a proper library.. at some point.
+ *
+ * See: https://kubernetes.io/docs/api-reference/v1.8/
+ */
+final class KubernetesClient(endpoint: Uri, client: Client, serviceAccountToken: String) {
+  import KubernetesClient.cascadeDeletionPolicy
+  import KubernetesJson._
+
+  def createDeployment(namespace: String, stackName: StackName, image: Image, plan: Plan, ports: Option[Ports]): Task[Json] = {
+    val json = KubernetesJson.deployment(namespace,stackName, image, plan, ports)
+    val request = addCreds(Request(Method.POST, deploymentUri(namespace)))
+    client.expect[Json](request.withBody(json))
+  }
+
+  def createService(namespace: String, stackName: StackName, ports: Option[Ports]): Task[Json] = {
+    val json = KubernetesJson.service(namespace, stackName, ports)
+    val request = addCreds(Request(Method.POST, serviceUri(namespace)))
+    client.expect[Json](request.withBody(json))
+  }
+
+  def createCronJob(namespace: String, stackName: StackName, image: Image, plan: Plan, cronExpr: String): Task[Json] = {
+    val json = KubernetesJson.cronJob(namespace, stackName, image, plan, cronExpr)
+    val request = addCreds(Request(Method.POST, cronJobUri(namespace)))
+    client.expect[Json](request.withBody(json))
+  }
+
+  def createJob(namespace: String, stackName: StackName, image: Image, plan: Plan): Task[Json] = {
+    val json = KubernetesJson.job(namespace, stackName, image, plan)
+    val request = addCreds(Request(Method.POST, jobUri(namespace)))
+    client.expect[Json](request.withBody(json))
+  }
+
+  def deleteDeployment(namespace: String, name: String): Task[Json] = {
+    val request = addCreds(Request(Method.DELETE, deploymentUri(namespace) / name))
+    client.expect[Json](request.withBody(cascadeDeletionPolicy))
+  }
+
+  def deleteService(namespace: String, name: String): Task[Json] = {
+    val request = addCreds(Request(Method.DELETE, serviceUri(namespace) / name))
+    client.expect[Json](request.withBody(cascadeDeletionPolicy))
+  }
+
+  def deleteCronJob(namespace: String, name: String): Task[Json] = {
+    val request = addCreds(Request(Method.DELETE, cronJobUri(namespace) / name))
+    client.expect[Json](request.withBody(cascadeDeletionPolicy))
+  }
+
+  def deleteJob(namespace: String, name: String): Task[Json] = {
+    val request = addCreds(Request(Method.DELETE, jobUri(namespace) / name))
+    client.expect[Json](request.withBody(cascadeDeletionPolicy))
+  }
+
+  def deploymentSummary(namespace: String, name: String): Task[DeploymentStatus] = {
+    val request = addCreds(Request(Method.GET, deploymentUri(namespace) / name / "status"))
+    client.expect[DeploymentStatus](request)(jsonOf[DeploymentStatus])
+  }
+
+  def cronJobSummary(namespace: String, name: String): Task[JobStatus] = {
+    // CronJob status doesn't give very useful information so we leverage Nelson-specific
+    // information (the stackName label applied to cron jobs deployed by Nelson) to get status information
+    val selector = s"stackName=${name}"
+    val selectedUri = jobUri(namespace).withQueryParam("labelSelector", selector)
+    val request = addCreds(Request(Method.GET, selectedUri))
+
+    val decoder: DecodeJson[List[JobStatus]] = DecodeJson(c => (c --\ "items").as[List[JobStatus]])
+    client.expect[List[JobStatus]](request)(jsonOf(decoder)).map((jss: List[JobStatus])=> Foldable[List].fold(jss))
+  }
+
+  def jobSummary(namespace: String, name: String): Task[JobStatus] = {
+    val request = addCreds(Request(Method.GET, jobUri(namespace) / name / "status"))
+    client.expect[JobStatus](request)(jsonOf[JobStatus])
+  }
+
+  def listPods(namespace: String, labelSelectors: Map[String, String]): Task[List[HealthStatus]] = {
+    val selectors = labelSelectors.map { case (k, v) => s"${k}=${v}"}.mkString(",")
+    val uri = podUri(namespace).withQueryParam("labelSelector", selectors)
+    val request = addCreds(Request(Method.GET, uri))
+
+    implicit val statusDecoder = healthStatusDecoder
+    val decoder: DecodeJson[List[HealthStatus]] = DecodeJson(c => (c --\ "items").as[List[HealthStatus]])
+    client.expect[List[HealthStatus]](request)(jsonOf(decoder))
+  }
+
+  private def addCreds(req: Request): Request =
+    req.putHeaders(Authorization(Token(AuthScheme.Bearer, serviceAccountToken)))
+
+  private def podUri(ns: String): Uri =
+    endpoint / "api"  /           "v1"      / "namespaces" / ns / "pods"
+
+  private def deploymentUri(ns: String): Uri =
+    endpoint / "apis" / "apps"  / "v1beta2" / "namespaces" / ns / "deployments"
+
+  private def serviceUri(ns: String): Uri =
+    endpoint / "api"  /           "v1"      / "namespaces" / ns / "services"
+
+  private def cronJobUri(ns: String): Uri =
+    endpoint / "apis" / "batch" / "v1beta1" / "namespaces" / ns / "cronjobs"
+
+  private def jobUri(ns: String): Uri =
+    endpoint / "apis" / "batch" / "v1"      / "namespaces" / ns / "jobs"
+}
+
+object KubernetesClient {
+  // Cascade deletes - deleting a Deployment should delete the associated ReplicaSet and Pods
+  // See: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
+  private val cascadeDeletionPolicy = argonaut.Json(
+    "kind" := "DeleteOptions",
+    "apiVersion" := "v1",
+    "propagationPolicy" := "Foreground"
+  )
+}
+
+object KubernetesJson {
+  def deployment(
+    namespace: String,
+    stackName: StackName,
+    image:     Image,
+    plan:      Plan,
+    ports:     Option[Ports]
+  ): Json =
+    argonaut.Json(
+      "apiVersion" := "apps/v1beta2",
+      "kind"       := "Deployment",
+      "metadata"   := argonaut.Json(
+        "name"      := stackName.toString,
+        "namespace" := namespace,
+        "labels"    := argonaut.Json(
+          "stackName"   := stackName.toString,
+          "serviceName" := stackName.serviceType,
+          "version"     := stackName.version.toString,
+          "nelson"      := "true"
+        )
+      ),
+      "spec" := argonaut.Json(
+        "replicas" := plan.environment.desiredInstances.getOrElse(1),
+        "selector" := argonaut.Json(
+          "matchLabels" := argonaut.Json("stackName" := stackName.toString)
+        ),
+        "template" := argonaut.Json(
+          "metadata" := argonaut.Json(
+            "labels" := argonaut.Json(
+              "stackName"   := stackName.toString,
+              "serviceName" := stackName.serviceType,
+              "version"     := stackName.version.toString,
+              "nelson"      := "true"
+            )
+          ),
+          "spec" := argonaut.Json(
+            "containers" := List(
+              argonaut.Json(
+                "name"  := stackName.toString,
+                "image" := image.toString,
+                "ports" := containerPortsJson(ports.toList.flatMap(_.nel.list))
+              )
+            )
+          )
+        )
+      )
+    )
+
+  def service(namespace: String, stackName: StackName, ports: Option[Ports]): Json =
+    argonaut.Json(
+      "apiVersion" := "v1",
+      "kind"       := "Service",
+      "metadata"   := argonaut.Json(
+        "name"      := stackName.toString,
+        "namespace" := namespace,
+        "labels"    := argonaut.Json(
+          "stackName"   := stackName.toString,
+          "serviceName" := stackName.serviceType,
+          "version"     := stackName.version.toString,
+          "nelson"      := "true"
+        )
+      ),
+      "spec" := argonaut.Json(
+        "selector" := argonaut.Json("stackName" := stackName.toString),
+        "ports"    := servicePortsJson(ports.toList.flatMap(_.nel.list)),
+        "type"     := "ClusterIP"
+      )
+    )
+
+  def cronJob(
+    namespace: String,
+    stackName: StackName,
+    image:     Image,
+    plan:      Plan,
+    cronExpr:  String
+  ): Json =
+    argonaut.Json(
+      "apiVersion" := "batch/v1beta1",
+      "kind"       := "CronJob",
+      "metadata"   := argonaut.Json(
+        "name"      := stackName.toString,
+        "namespace" := namespace,
+        "labels"    := argonaut.Json(
+          "stackName"   := stackName.toString,
+          "serviceName" := stackName.serviceType,
+          "version"     := stackName.version.toString,
+          "nelson"      := "true"
+        )
+      ),
+      "spec" := argonaut.Json(
+        "schedule"    := cronExpr,
+        "jobTemplate" := argonaut.Json.jObject(jobSpecJson(stackName, image, plan))
+      )
+    )
+
+  def job(
+    namespace: String,
+    stackName: StackName,
+    image:     Image,
+    plan:      Plan
+  ): Json =
+    argonaut.Json.jObject(combineJsonObject(JsonObject.from(List(
+      "apiVersion" := "batch/v1",
+      "kind"       := "Job",
+      "metadata"   := argonaut.Json(
+        "name"      := stackName.toString,
+        "namespace" := namespace,
+        "labels"    := argonaut.Json(
+          "stackName"   := stackName.toString,
+          "serviceName" := stackName.serviceType,
+          "version"     := stackName.version.toString,
+          "nelson"      := "true"
+        )
+      )
+    )), jobSpecJson(stackName, image, plan)))
+
+  private def jobSpecJson(
+    stackName: StackName,
+    image:     Image,
+    plan:      Plan
+  ): JsonObject = {
+    val backoffLimit = plan.environment.retries.fold(JsonObject.empty) { retries =>
+      JsonObject.single("backoffLimit", retries.asJson)
+    }
+
+    JsonObject.from(List(
+      "spec" := argonaut.Json.jObject(combineJsonObject(JsonObject.from(List(
+        "completions"  := plan.environment.desiredInstances.getOrElse(1),
+        "template"     := argonaut.Json(
+          "metadata" := argonaut.Json(
+            "name" := stackName.toString,
+            "labels" := argonaut.Json(
+              "stackName"   := stackName.toString,
+              "serviceName" := stackName.serviceType,
+              "version"     := stackName.version.toString,
+              "nelson"      := "true"
+            )
+          ),
+          "spec" := argonaut.Json(
+            "containers" := List(
+              argonaut.Json(
+                "name"  := stackName.toString,
+                "image" := image.toString
+              )
+            ),
+            "restartPolicy" := "OnFailure"
+          )
+        )
+      )), backoffLimit))
+    ))
+  }
+
+  // Status seems to be largely undocumented in the K8s docs, so your best bet is to stare at
+  // https://github.com/kubernetes/kubernetes/tree/master/api/openapi-spec
+  // Recommend using 'jq' for your sanity
+
+  final case class DeploymentStatus(
+    availableReplicas:   Option[Int],
+    unavailableReplicas: Option[Int]
+  )
+
+  object DeploymentStatus {
+    implicit val deploymentStatusDecoder: DecodeJson[DeploymentStatus] =
+      DecodeJson(c => {
+        val status = c --\ "status"
+        for {
+          availableReplicas   <- (status --\ "availableReplicas").as[Option[Int]]
+          unavailableReplicas <- (status --\ "unavailableReplicas").as[Option[Int]]
+        } yield DeploymentStatus(availableReplicas, unavailableReplicas)
+      })
+  }
+
+  final case class JobStatus(
+    active:    Option[Int],
+    failed:    Option[Int],
+    succeeded: Option[Int]
+  )
+
+  object JobStatus {
+    implicit val jobStatusDecoder: DecodeJson[JobStatus] =
+      DecodeJson(c => {
+        val status = c --\ "status"
+        for {
+          active    <- (status --\ "active").as[Option[Int]]
+          failed    <- (status --\ "failed").as[Option[Int]]
+          succeeded <- (status --\ "succeeded").as[Option[Int]]
+        } yield JobStatus(active, failed, succeeded)
+      })
+
+    implicit val jobStatusMonoid: Monoid[JobStatus] = new Monoid[JobStatus] {
+      def append(f1: JobStatus, f2: => JobStatus): JobStatus =
+        JobStatus(
+          active =    f1.active    |+| f2.active,
+          failed =    f1.failed    |+| f2.failed,
+          succeeded = f1.succeeded |+| f2.succeeded
+        )
+
+      def zero: JobStatus = JobStatus(None, None, None)
+    }
+  }
+
+  private def combineJsonObject(x: JsonObject, y: JsonObject): JsonObject =
+    JsonObject.from(x.toList ++ y.toList)
+
+  private def containerPortsJson(ports: List[Port]): List[Json] =
+    ports.map { port =>
+      argonaut.Json(
+        "name"          := port.ref,
+        "containerPort" := port.port
+      )
+    }
+
+  private def servicePortsJson(ports: List[Port]): List[Json] =
+    ports.map { port =>
+      argonaut.Json(
+        "name"       := port.ref,
+        "port"       := port.port,
+        "targetPort" := port.port
+      )
+    }
+
+  val healthStatusDecoder: DecodeJson[HealthStatus] =
+    DecodeJson(c =>
+      for {
+        name    <- (c --\ "metadata" --\ "name").as[String]
+        status  <- (c --\ "status"   --\ "phase").as[String].map(parsePodHealthCheck)
+        node    <- (c --\ "spec"     --\ "nodeName").as[String]
+        details <- (c --\ "status"   --\ "message").as[Option[String]]
+      } yield HealthStatus(name, status, node, details)
+    )
+
+  // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+  private def parsePodHealthCheck(s: String): HealthCheck = s match {
+    case "Running" => Passing
+    case "Failed"  => Failing
+    case _         => Unknown
+  }
+}

--- a/core/src/main/scala/Nelson.scala
+++ b/core/src/main/scala/Nelson.scala
@@ -590,7 +590,7 @@ object Nelson {
         a   <- OptionT(storage.run(cfg.storage, query))
         (dep, exp, status, ns) = a
         dc  <- OptionT(Task.now(cfg.datacenters.find(_.name == ns.datacenter)))
-        sum <- OptionT(scheduler.run(dc.interpreters.scheduler, scheduler.SchedulerOp.summary(dc, dep.stackName)))
+        sum <- OptionT(scheduler.run(dc.interpreters.scheduler, scheduler.SchedulerOp.summary(dc, ns.name, dep.stackName)))
         h   <- OptionT(health.run(dc.health, HealthCheckOp.health(dc, ns.name, dep.stackName)).map(h => Some(h): Option[List[HealthStatus]]))
       } yield RuntimeSummary(sum, h, status, exp)).run
     }

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -51,7 +51,7 @@ trait Workflow[O] {
 object Workflow {
 
   // There's currently only one workflow implementation.
-  val workflows = List(Magnetar)
+  val workflows = List(Magnetar, Canopus)
 
   def fromString(s: String): Option[Workflow[Unit]] =
     workflows.find(_.name == s)

--- a/core/src/main/scala/health/KubernetesHealthClient.scala
+++ b/core/src/main/scala/health/KubernetesHealthClient.scala
@@ -1,0 +1,18 @@
+package nelson
+package health
+
+import scalaz.~>
+import scalaz.concurrent.Task
+
+import nelson.Datacenter.StackName
+import nelson.KubernetesJson.DeploymentStatus
+import nelson.health.HealthCheckOp.Health
+
+final case class KubernetesHealthClient(client: KubernetesClient) extends (HealthCheckOp ~> Task) {
+  def apply[A](fa: HealthCheckOp[A]): Task[A] = fa match {
+    case Health(dc, ns, sn) =>
+      val rootNs = ns.root.asString
+      val selectors = Map(("stackName", sn.toString), ("nelson", "true"))
+      client.listPods(rootNs, selectors)
+  }
+}

--- a/core/src/main/scala/scheduler/DeploymentSummary.scala
+++ b/core/src/main/scala/scheduler/DeploymentSummary.scala
@@ -17,6 +17,10 @@
 package nelson
 package scheduler
 
+import scalaz.Monoid
+import scalaz.std.anyVal._
+import scalaz.std.option._
+import scalaz.syntax.monoid._
 
 final case class DeploymentSummary(
   running: Option[Int],
@@ -24,3 +28,19 @@ final case class DeploymentSummary(
   completed: Option[Int],
   failed: Option[Int]
 )
+
+object DeploymentSummary {
+  implicit val deploymentSummaryMonoid: Monoid[DeploymentSummary] =
+    new Monoid[DeploymentSummary] {
+      def append(f1: DeploymentSummary, f2: => DeploymentSummary): DeploymentSummary =
+        DeploymentSummary(
+          running =   f1.running   |+| f2.running,
+          pending =   f1.pending   |+| f2.pending,
+          completed = f1.completed |+| f2.completed,
+          failed =    f1.failed    |+| f2.failed
+        )
+
+      def zero: DeploymentSummary =
+        DeploymentSummary(None, None, None, None)
+    }
+}

--- a/core/src/main/scala/scheduler/KubernetesHttp.scala
+++ b/core/src/main/scala/scheduler/KubernetesHttp.scala
@@ -1,0 +1,153 @@
+package nelson
+package scheduler
+
+import argonaut._
+import argonaut.Argonaut._
+import journal.Logger
+import org.http4s.Status.NotFound
+import org.http4s.client.UnexpectedStatus
+import scalaz.{~>, Foldable}
+import scalaz.Scalaz._
+import scalaz.concurrent.Task
+
+import nelson.KubernetesJson.{DeploymentStatus, JobStatus}
+import nelson.Datacenter.{Deployment, StackName}
+import nelson.Manifest.{EnvironmentVariable, Plan, Ports, Port, UnitDef, Versioned}
+import nelson.docker.Docker.Image
+import nelson.scheduler.SchedulerOp._
+
+object KubernetesHttp {
+  private val log = Logger[KubernetesHttp.type]
+}
+
+/**
+ * SchedulerOp interpreter that uses the Kubernetes API server.
+ *
+ * See: https://kubernetes.io/docs/api-reference/v1.8/
+ */
+final class KubernetesHttp(client: KubernetesClient) extends (SchedulerOp ~> Task) {
+  import KubernetesHttp.log
+
+  def apply[A](fa: SchedulerOp[A]): Task[A] = fa match {
+    case Delete(dc, deployment) =>
+      delete(dc, deployment)
+    case Launch(image, dc, ns, unit, plan, hash) =>
+      launch(image, dc, ns, Versioned.unwrap(unit), unit.version, plan, hash)
+    case Summary(dc, ns, stackName) =>
+      summary(dc, ns, stackName)
+
+    // TODO: Legacy, no longer used
+    case RunningUnits(dc, prefix) =>
+      Task.delay {
+        log.debug(s"KubernetesHttp RunningUnits(${dc}, ${prefix})")
+        Set.empty
+      }
+  }
+
+  def delete(dc: Datacenter, deployment: Deployment): Task[Unit] = {
+    val rootNs = deployment.namespace.name.root.asString
+    val name = deployment.stackName.toString
+
+    // Kubernetes has different endpoints for deployments, cron jobs, and jobs - given just
+    // the name we don't know which one it is so we try each one in turn, presumably the
+    // most common types first
+    val deleteService =
+      (client.deleteDeployment(rootNs, name) |@| client.deleteService(rootNs, name)) { case (_, _) => () }
+
+    deleteService.handleWith {
+      case UnexpectedStatus(NotFound) =>
+        client.deleteCronJob(rootNs, name).map(_ => ()).handleWith {
+          case UnexpectedStatus(NotFound) =>
+            client.deleteJob(rootNs, name).map(_ => ()).handleWith {
+              // at this point swallow 404, as we're being asked to delete something that does not exist
+              // this can happen when a workflow fails and the cleanup process is subsequently called
+              case UnexpectedStatus(NotFound) => Task.now(())
+            }
+        }
+    }
+  }
+
+  def launch(image: Image, dc: Datacenter, ns: NamespaceName, unit: UnitDef, version: Version, plan: Plan, hash: String): Task[String] = {
+    val stackName = StackName(unit.name, version, hash)
+    val env = plan.environment.bindings ++ List(
+      EnvironmentVariable("NELSON_STACKNAME",        stackName.toString),
+      EnvironmentVariable("NELSON_DATACENTER",       dc.name),
+      EnvironmentVariable("NELSON_ENV",              ns.root.asString),
+      EnvironmentVariable("NELSON_NAMESPACE",        ns.asString),
+      EnvironmentVariable("NELSON_DNS_ROOT",         dc.domain.name),
+      EnvironmentVariable("NELSON_PLAN",             plan.name),
+      EnvironmentVariable("NELSON_DOCKER_IMAGE",     image.toString),
+      EnvironmentVariable("NELSON_MEMORY_LIMIT",     plan.environment.memory.getOrElse(512D).toInt.toString),
+      EnvironmentVariable("NELSON_NODENAME",         s"$${node.unique.name}"),
+      EnvironmentVariable("NELSON_VAULT_POLICYNAME", NomadJson.getPolicyName(ns, stackName.toString))
+    )
+    val newPlan = plan.copy(environment = plan.environment.copy(bindings = env))
+    val schedule = Manifest.getSchedule(unit, plan)
+
+    val rootNs = ns.root.asString
+    val response = schedule match {
+      case None        =>
+        (client.createDeployment(rootNs, stackName, image, newPlan, unit.ports) |@| client.createService(rootNs, stackName, unit.ports)) {
+          case (deployment, service) => Json("deployment" := deployment, "service" := service)
+        }
+      case Some(sched) =>
+        sched.toCron match {
+          case None           => client.createJob(rootNs, stackName, image, newPlan)
+          case Some(cronExpr) => client.createCronJob(rootNs, stackName, image, newPlan, cronExpr)
+        }
+    }
+
+    response.map(_.nospaces)
+  }
+
+  def summary(dc: Datacenter, ns: NamespaceName, stackName: StackName): Task[Option[DeploymentSummary]] = {
+    // K8s has different endpoints for Deployment, CronJob, and Job, so we hit all of them until we find one
+    deploymentSummary(dc, ns, stackName).handleWith {
+      case UnexpectedStatus(NotFound) =>
+        cronJobSummary(dc, ns, stackName).handleWith {
+          case UnexpectedStatus(NotFound) =>
+            jobSummary(dc, ns, stackName).handleWith {
+              case UnexpectedStatus(NotFound) => Task.now(None)
+            }
+        }
+    }
+  }
+
+  private def deploymentSummary(dc: Datacenter, ns: NamespaceName, stackName: StackName): Task[Option[DeploymentSummary]] = {
+    val rootNs = ns.root.asString
+
+    client.deploymentSummary(rootNs, stackName.toString).map {
+      case DeploymentStatus(availableReplicas, unavailableReplicas) =>
+        Some(DeploymentSummary(
+          running   = availableReplicas,
+          pending   = unavailableReplicas,
+          completed = None,
+          failed    = None
+        ))
+    }
+  }
+
+  private def cronJobSummary(dc: Datacenter, ns: NamespaceName, stackName: StackName): Task[Option[DeploymentSummary]] = {
+    val rootNs = ns.root.asString
+
+    client.cronJobSummary(rootNs, stackName.toString).map {
+      case js@JobStatus(_, _, _) => Some(jobStatusToSummary(js))
+    }
+  }
+
+  private def jobSummary(dc: Datacenter, ns: NamespaceName, stackName: StackName): Task[Option[DeploymentSummary]] = {
+    val rootNs = ns.root.asString
+
+    client.jobSummary(rootNs, stackName.toString).map {
+      case js@JobStatus(_, _, _) => Some(jobStatusToSummary(js))
+    }
+  }
+
+  private def jobStatusToSummary(js: JobStatus): DeploymentSummary =
+    DeploymentSummary(
+      running   = js.active,
+      pending   = None,         // Doesn't seem like K8s API gives this info
+      completed = js.succeeded,
+      failed    = js.failed
+    )
+}

--- a/core/src/main/scala/scheduler/NomadHttp.scala
+++ b/core/src/main/scala/scheduler/NomadHttp.scala
@@ -56,7 +56,7 @@ final class NomadHttp(cfg: NomadConfig, nomad: Infrastructure.Nomad, client: org
       case Launch(i, dc, ns, u, p, hash) =>
         val unit = Manifest.Versioned.unwrap(u)
         launch(unit, hash, u.version, i, dc, ns, p).retryExponentially()
-      case Summary(dc,sn) =>
+      case Summary(dc,_,sn) =>
         summary(dc,sn)
       case RunningUnits(dc, prefix) =>
         runningUnits(dc, prefix)

--- a/core/src/main/scala/scheduler/SchedulerOp.scala
+++ b/core/src/main/scala/scheduler/SchedulerOp.scala
@@ -29,7 +29,7 @@ object SchedulerOp {
 
   final case class Launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String) extends SchedulerOp[String]
 
-  final case class Summary(dc: Datacenter, sn: Datacenter.StackName) extends SchedulerOp[Option[DeploymentSummary]]
+  final case class Summary(dc: Datacenter, ns: NamespaceName, sn: Datacenter.StackName) extends SchedulerOp[Option[DeploymentSummary]]
 
   final case class RunningUnits(dc: Datacenter, prefix: Option[String]) extends SchedulerOp[Set[RunningUnit]]
 
@@ -41,8 +41,8 @@ object SchedulerOp {
   def delete(dc: Datacenter, d: Datacenter.Deployment): SchedulerF[Unit] =
     Free.liftFC(Delete(dc,d))
 
-  def summary(dc: Datacenter, sn: Datacenter.StackName): SchedulerF[Option[DeploymentSummary]] =
-    Free.liftFC(Summary(dc,sn))
+  def summary(dc: Datacenter, ns: NamespaceName, sn: Datacenter.StackName): SchedulerF[Option[DeploymentSummary]] =
+    Free.liftFC(Summary(dc,ns,sn))
 
   def runningUnits(dc: Datacenter, prefix: Option[String] = None): SchedulerF[Set[RunningUnit]] =
     Free.liftFC(RunningUnits(dc, prefix))

--- a/core/src/main/scala/workflows/Canopus.scala
+++ b/core/src/main/scala/workflows/Canopus.scala
@@ -1,0 +1,54 @@
+package nelson
+
+import scalaz.@@
+import scalaz.syntax.apply._
+import nelson.ScalazHelpers._
+
+import nelson.Datacenter.{Deployment, Namespace => DCNamespace}
+import nelson.DeploymentStatus.{Pending, Ready, Terminated, Warming}
+import nelson.Manifest.{Namespace => ManifestNamespace, Plan, UnitDef, Versioned}
+import nelson.Workflow.WorkflowF
+import nelson.Workflow.syntax._
+import nelson.docker.DockerOp
+
+/**
+ * Kubernetes deployment workflow that just deploys and deletes units. No Vault policy
+ * or traffic shifting (yet!).
+ *
+ * This workflow is named after the Canopus star which represents King Menelaus's helmsman in Greek
+ * mythology. Canopus is a star in the Carina constellation, which in turn was once part of the
+ * Argo constellation, named after the ship used by Jason and the Argonauts.
+ *
+ * The name here is inspired by the existing use of astronomical names (see the Magnetar workflow),
+ * "kubernetes" which is Greek for helmsman, and Nelson's usage of the Argonaut library for J(a)SON parsing.
+ */
+object Canopus extends Workflow[Unit] {
+  val name: WorkflowRef = "canopus"
+
+  def deploy(id: ID, hash: String, vunit: UnitDef @@ Versioned, p: Plan, dc: Datacenter, ns: ManifestNamespace): WorkflowF[Unit] = {
+    // When the workflow is completed, we typically want to set the deployment to "Warming", so that once
+    // consul indicates the deployment to be passing the health check, we can promote to "Ready" (via the
+    // DeploymentMonitor background process).  However, units without ports are not registered in consul, and
+    // thus we should immediately advance mark the deployment as "Ready".  Once Reconciliation is also used as
+    // a gating factor for promoting deployments to "Ready", we can potentially set all units to "Warming" here.
+    def getStatus(unit: UnitDef, plan: Plan):  DeploymentStatus =
+      if (Manifest.isPeriodic(unit,plan)) Ready
+      else unit.ports.fold[DeploymentStatus](Ready)(_ => Warming)
+
+    for {
+      i <- DockerOp.extract(Versioned.unwrap(vunit)).inject
+      _ <- status(id, Pending, "Canopus workflow about to start")
+      _ <- logToFile(id, s"Instructing ${dc.name}'s scheduler to handle service container")
+      l <- launch(i, dc, ns.name, vunit, p, hash)
+      _ <- debug(s"Scheduler responded with: ${l}")
+      _ <- status(id, getStatus(Manifest.Versioned.unwrap(vunit), p), "=====> Canopus workflow completed <=====")
+    } yield ()
+  }
+
+  def destroy(d: Deployment, dc: Datacenter, ns: DCNamespace): WorkflowF[Unit] = {
+    val stackName = d.stackName
+    logToFile(d.id, s"Instructing ${dc.name}'s scheduler to decomission ${stackName}") *>
+    delete(dc, d) *>
+    status(d.id, Terminated, s"Decomissioning deployment ${stackName} in ${dc.name}")
+  }
+}

--- a/core/src/test/resources/nelson/datacenters-missing-consul.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-consul.cfg
@@ -30,6 +30,7 @@ nelson {
 
       infrastructure {
        scheduler {
+          scheduler = "nomad"
           nomad {
             endpoint  = "https://nomad.service"
             timeout   = 1 second
@@ -74,6 +75,7 @@ nelson {
 
       infrastructure {
        scheduler {
+          scheduler = "nomad"
           nomad {
             endpoint  = "https://nomad.service"
             timeout   = 1 second

--- a/core/src/test/resources/nelson/datacenters-missing-domain.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-domain.cfg
@@ -29,6 +29,7 @@ nelson {
 
       infrastructure {
         scheduler {
+          scheduler = "nomad"
           nomad {
             endpoint  = "https://nomad.service"
             timeout   = 1 second

--- a/core/src/test/resources/nelson/datacenters.cfg
+++ b/core/src/test/resources/nelson/datacenters.cfg
@@ -29,6 +29,7 @@ nelson {
       }
       infrastructure {
         scheduler {
+          scheduler = "nomad"
           nomad {
             endpoint  = "https://nomad.service"
             timeout   = 1 second
@@ -83,6 +84,7 @@ nelson {
       infrastructure {
 
         scheduler {
+          scheduler = "nomad"
           nomad {
             endpoint  = "https://nomad.service"
             timeout   = 1 second

--- a/core/src/test/scala/NelsonSuite.scala
+++ b/core/src/test/scala/NelsonSuite.scala
@@ -135,7 +135,7 @@ trait NelsonSuite
         Task.delay(sn.toString)
       case Delete(dc,d) =>
         Task.delay(())
-      case Summary(dc,ns) =>
+      case Summary(dc,ns,sn) =>
         Task.delay(None)
       case RunningUnits(dc, prefix) =>
         Task.now(Set.empty)

--- a/docs/src/hugo/content/index.md
+++ b/docs/src/hugo/content/index.md
@@ -686,6 +686,7 @@ nelson {
 
       infrastructure {
         scheduler {
+          scheduler = "nomad"
           nomad {
             # Where can Nelson access the Nomad leader cluster
             endpoint  = "https://nomad.service"

--- a/etc/development/docker/nelson.cfg
+++ b/etc/development/docker/nelson.cfg
@@ -44,6 +44,7 @@ nelson {
 
       infrastructure {
         scheduler {
+          scheduler = "nomad"
           nomad {
             endpoint = ""
             timeout = 1 second

--- a/etc/development/http/http.dev.cfg
+++ b/etc/development/http/http.dev.cfg
@@ -90,6 +90,7 @@ nelson {
 
       infrastructure {
         scheduler {
+          scheduler = "nomad"
           nomad {
            endpoint = "http://localhost:4646"
             timeout = 1 second


### PR DESCRIPTION
* Add Kubernetes interpreter for SchedulerOp
* Add new Canopus workflow for Kubernetes deployments
* Add new 'scheduler' field in config to choose between Nomad or Kubernetes
* Add support for SSLContext in HTTP4S Client creation
* Add namespace to Summary ctor since Kubernetes needs that

Also:
* Change Alpine APK endpoint as original one didn't seem to work anymore
* Remove Allocations, was only used in reconcilliation which was removed in #48