### PR TITLE
Use the Docker that Alpine gives us

### DIFF
--- a/http/build.sbt
+++ b/http/build.sbt
@@ -72,8 +72,7 @@ dockerCommands ++= Seq(
   ExecCmd("RUN", "ln", "-s", s"${(defaultLinuxInstallLocation in Docker).value}/bin/${normalizedName.value}", "/usr/local/bin/sbt"),
   ExecCmd("RUN", "chmod", "555", s"${(defaultLinuxInstallLocation in Docker).value}/bin/${normalizedName.value}"),
   ExecCmd("RUN", "chown", "-R", "nelson:nelson", s"${(defaultLinuxInstallLocation in Docker).value}"),
-  ExecCmd("RUN", "apk", "add", "--update-cache", "bash", "graphviz", "wget", "libc6-compat"),
-  ExecCmd("RUN", "apk", "add", "docker=1.9.1-r2", "--update-cache", "--repository", "http://dl-3.alpinelinux.org/alpine/v3.3/community/")
+  ExecCmd("RUN", "apk", "add", "--update-cache", "bash", "graphviz", "wget", "libc6-compat", "docker")
 )
 
 // Install promtool.  It needs to be on the PATH for validation.


### PR DESCRIPTION
dl-3 no longer has the Docker artifact we need.  dl-2 does, but it's an old version and leaves us open to the mutability of what lies behind dl-cdn.  Instead, this uses the version of Docker (17.05.0-r0) that is in our version of alpine.

The risk is that we have trouble digesting the output, but if so, we can deal with that in a subsequent revision.  The build is broke anyway, yo.