### PR TITLE
Remove remaining Tasks and cleanup some migrations

### DIFF
--- a/core/src/main/scala/Metrics.scala
+++ b/core/src/main/scala/Metrics.scala
@@ -17,7 +17,6 @@
 package nelson
 
 import cats.effect.IO
-import cats.syntax.applicativeError._
 import cats.syntax.apply._
 
 import io.prometheus.client._
@@ -168,7 +167,10 @@ object Metrics {
         _       <- onComplete.run(elapsed)
       } yield a
 
-      (io <* onSuccess).onError { case err => onFail(err) }
+      io.attempt.flatMap {
+        case Left(e)  => onFail(e) *> IO.raiseError(e)
+        case Right(a) => onSuccess *> IO.pure(a)
+      }
     }
   }
 }

--- a/core/src/main/scala/Templates.scala
+++ b/core/src/main/scala/Templates.scala
@@ -159,7 +159,7 @@ object Templates {
         consulTemplateContainersRunning.inc()
         val exitCode = cmd.!(pLogger)
         exitCode
-      }.unsafeTimed(templateConfig.timeout)(ec, scheduler).attempt.flatMap {
+      }.timed(templateConfig.timeout)(ec, scheduler).attempt.flatMap {
         // ^ NOTE: This will return when the timeout is up but will not cancel
         // the already running action - that is pending https://github.com/typelevel/cats-effect/pull/121
         case Right(0) =>

--- a/http/src/main/scala/Main.scala
+++ b/http/src/main/scala/Main.scala
@@ -93,7 +93,7 @@ object Main {
       runBackgroundJob("deployment_monitor", DeploymentMonitor.loop(cfg))
 
       registerJvmMetrics()
-      MonitoringServer(port = cfg.network.monitoringPort).attemptRun.fold(
+      MonitoringServer(port = cfg.network.monitoringPort).attempt.unsafeRunSync().fold(
         e => {
           log.error(s"fatal error starting monitoring server: '$e'")
           e.printStackTrace

--- a/http/src/main/scala/MonitoringServer.scala
+++ b/http/src/main/scala/MonitoringServer.scala
@@ -27,7 +27,8 @@ import io.prometheus.client.exporter.common.TextFormat
 import journal.Logger
 
 import scala.concurrent.duration._
-import scalaz.concurrent.Task
+
+import cats.effect.IO
 
 object MonitoringServer {
   /**
@@ -37,7 +38,7 @@ object MonitoringServer {
   def apply(
     registry: CollectorRegistry = CollectorRegistry.defaultRegistry,
     port: Int = 5775,
-    keyTTL: Duration = 36.hours): Task[MonitoringServer] = Task.delay {
+    keyTTL: Duration = 36.hours): IO[MonitoringServer] = IO {
     val svr = (new MonitoringServer(registry, port, keyTTL))
     svr.start()
     svr
@@ -78,7 +79,7 @@ class MonitoringServer private (
   /**
    * Returns a Task to stop this server
    */
-  def stop: Task[Unit] = Task.delay { server.stop(0) }
+  def stop: IO[Unit] = IO { server.stop(0) }
 
   protected def handler = new HttpHandler {
     def handle(req: HttpExchange): Unit = try {

--- a/project/versions.scala
+++ b/project/versions.scala
@@ -24,7 +24,6 @@ object V {
   val knobs            = "6.0.33"
   val prometheus       = "0.0.21"
   val scalaz           = "7.1.11"
-  val scalazStream     = "0.8.6"
   val scodec           = "1.9.0"
   val dockerit         = "0.9.0-RC1"
 


### PR DESCRIPTION
- Change unsafeTimed to be safe using new IO cancellation feature
- Make Metrics.timer logic clearer
- Replace remaining uses of Task with IO