### PR TITLE
More Kubernetes features and additions

### DIFF
--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -83,10 +83,9 @@ object Infrastructure {
 
   sealed abstract class KubernetesMode extends Product with Serializable {
     def caCert: Path = this match {
-      /** All pods in Kubernetes get a cert mounted at this path.
-        * See https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
-        * for more info.
-        */
+      // All pods in Kubernetes get a cert mounted at this path.
+      // See https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+      // for more info.
       case KubernetesMode.InCluster => Paths.get("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
       case KubernetesMode.OutCluster(p, _) => p
     }

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -36,7 +36,7 @@ import helm.ConsulOp
 
 import java.net.URI
 import java.time.Instant
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 import org.http4s.Uri
 
@@ -77,10 +77,25 @@ object Infrastructure {
   final case class Kubernetes(
     endpoint: Uri,
     version: KubernetesVersion,
-    caCertPath: Path,
-    token: String,
-    timeout: Duration
+    timeout: Duration,
+    mode: KubernetesMode
   )
+
+  sealed abstract class KubernetesMode extends Product with Serializable {
+    def caCert: Path = this match {
+      /** All pods in Kubernetes get a cert mounted at this path.
+        * See https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+        * for more info.
+        */
+      case KubernetesMode.InCluster => Paths.get("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+      case KubernetesMode.OutCluster(p, _) => p
+    }
+  }
+
+  object KubernetesMode {
+    final case object InCluster extends KubernetesMode
+    final case class OutCluster(caCertPath: Path, token: String) extends KubernetesMode
+  }
 
   final case class SplunkConfig(
     splunkUrl: String,

--- a/core/src/main/scala/Exceptions.scala
+++ b/core/src/main/scala/Exceptions.scala
@@ -225,6 +225,8 @@ object YamlError {
   def invalidNamespace(n: String, reason: String): YamlError = InvalidNamespace(n,reason)
   def emptyList(name: String): YamlError = EmptyList(name)
   def invalidMetaLength(meta: String): YamlError = InvalidMetaLength(meta)
+  val missingVolumeType: YamlError = MissingVolumeType
+  def invalidMountPath(path: String, reason: String): YamlError = InvalidMountPath(path, reason)
 }
 
 private final case class InvalidExternalAddress(uri: String)
@@ -337,3 +339,9 @@ private final case class EmptyList(field: String)
 
 private final case class InvalidMetaLength(meta: String)
   extends YamlError(s"""meta ($meta) must less that or equal to 14 characters""")
+
+private final case object MissingVolumeType
+  extends YamlError(s"missing volume type in volume manifest")
+
+private final case class InvalidMountPath(path: String, reason: String)
+  extends YamlError(s"${path} is an invalid mount path: ${reason}")

--- a/core/src/main/scala/Exceptions.scala
+++ b/core/src/main/scala/Exceptions.scala
@@ -225,8 +225,10 @@ object YamlError {
   def invalidNamespace(n: String, reason: String): YamlError = InvalidNamespace(n,reason)
   def emptyList(name: String): YamlError = EmptyList(name)
   def invalidMetaLength(meta: String): YamlError = InvalidMetaLength(meta)
-  val missingVolumeType: YamlError = MissingVolumeType
+  val missingVolumeName: YamlError = MissingVolumeName
   def invalidMountPath(path: String, reason: String): YamlError = InvalidMountPath(path, reason)
+  val missingVolumeSize: YamlError = MissingVolumeSize
+  def invalidVolumeSize(request: Int): YamlError = InvalidVolumeSize(request)
 }
 
 private final case class InvalidExternalAddress(uri: String)
@@ -340,8 +342,14 @@ private final case class EmptyList(field: String)
 private final case class InvalidMetaLength(meta: String)
   extends YamlError(s"""meta ($meta) must less that or equal to 14 characters""")
 
-private final case object MissingVolumeType
-  extends YamlError(s"missing volume type in volume manifest")
+private final case object MissingVolumeName
+  extends YamlError(s"Missing volume name in volume manifest.")
 
 private final case class InvalidMountPath(path: String, reason: String)
-  extends YamlError(s"${path} is an invalid mount path: ${reason}")
+  extends YamlError(s"${path} is an invalid mount path: ${reason}.")
+
+private final case object MissingVolumeSize
+  extends YamlError("Missing volume size in volume manifest.")
+
+private final case class InvalidVolumeSize(request: Int)
+  extends YamlError(s"$request is an invalid volume disk request, must be > 0 (measured in megabytes).")

--- a/core/src/main/scala/KubernetesClient.scala
+++ b/core/src/main/scala/KubernetesClient.scala
@@ -211,7 +211,7 @@ object KubernetesJson {
   }
 
   def volumeJson(volume: Volume): Json = argonaut.Json.jObject(volume match {
-    case Volume(id, _, VolumeType.EmptyDirectory(sizeInMb)) =>
+    case Volume(id, _, sizeInMb) =>
       JsonObject.fromTraversableOnce(List(
         "name" := id,
         "emptyDir" := argonaut.Json("sizeLimit" := s"${sizeInMb}M")

--- a/core/src/main/scala/KubernetesClient.scala
+++ b/core/src/main/scala/KubernetesClient.scala
@@ -23,15 +23,19 @@ import org.http4s.headers.Authorization
 sealed abstract class KubernetesVersion extends Product with Serializable
 
 object KubernetesVersion {
-  final case object `1.6` extends KubernetesVersion
-  final case object `1.7` extends KubernetesVersion
-  final case object `1.8` extends KubernetesVersion
+  final case object `1.6`  extends KubernetesVersion
+  final case object `1.7`  extends KubernetesVersion
+  final case object `1.8`  extends KubernetesVersion
+  final case object `1.9`  extends KubernetesVersion
+  final case object `1.10` extends KubernetesVersion
 
   def fromString(s: String): Option[KubernetesVersion] = s match {
-    case "1.6" => Some(`1.6`)
-    case "1.7" => Some(`1.7`)
-    case "1.8" => Some(`1.8`)
-    case _     => None
+    case "1.6"  => Some(`1.6`)
+    case "1.7"  => Some(`1.7`)
+    case "1.8"  => Some(`1.8`)
+    case "1.9"  => Some(`1.9`)
+    case "1.10" => Some(`1.10`)
+    case _      => None
   }
 }
 
@@ -131,9 +135,10 @@ final class KubernetesClient(version: KubernetesVersion, endpoint: Uri, client: 
 
   private def deploymentUri(ns: String): Uri = {
     val apiVersion = version match {
-      case `1.6` => "v1beta1"
-      case `1.7` => "v1beta1"
-      case `1.8` => "v1beta2"
+      case `1.6`          => "v1beta1"
+      case `1.7`          => "v1beta1"
+      case `1.8`          => "v1beta2"
+      case `1.9` | `1.10` => "v1"
     }
     endpoint / "apis" / "apps"  / apiVersion / "namespaces" / ns / "deployments"
   }
@@ -144,9 +149,9 @@ final class KubernetesClient(version: KubernetesVersion, endpoint: Uri, client: 
 
   private def cronJobUri(ns: String): Uri = {
     val apiVersion = version match {
-      case `1.6` => "v2alpha1"
-      case `1.7` => "v2alpha1"
-      case `1.8` => "v1beta1"
+      case `1.6`                  => "v2alpha1"
+      case `1.7`                  => "v2alpha1"
+      case `1.8` | `1.9` | `1.10` => "v1beta1"
     }
     endpoint / "apis" / "batch" / apiVersion / "namespaces" / ns / "cronjobs"
   }

--- a/core/src/main/scala/Manifest.scala
+++ b/core/src/main/scala/Manifest.scala
@@ -27,6 +27,7 @@ import cats.effect.IO
 import cats.implicits._
 
 import java.net.URI
+import java.nio.file.Path
 
 import scala.concurrent.duration._
 
@@ -114,6 +115,7 @@ object Manifest {
     schedule: Option[Schedule] = None,
     policy: Option[ExpirationPolicy] = None,
     trafficShift: Option[TrafficShift] = None,
+    volumes: List[Volume] = List.empty,
     ephemeralDisk: Option[Int] = None
   )
 
@@ -191,10 +193,16 @@ object Manifest {
   }
 
   final case class Volume(
-    mount: String,
-    source: String,
-    mode: String // rw, r
+    name: String,
+    mountPath: Path,
+    volumeType: VolumeType
   )
+
+  sealed abstract class VolumeType extends Product with Serializable
+
+  object VolumeType {
+    final case class EmptyDirectory(sizeInMb: Int) extends VolumeType
+  }
 
   final case class AlertOptOut(ref: String)
 

--- a/core/src/main/scala/Manifest.scala
+++ b/core/src/main/scala/Manifest.scala
@@ -192,17 +192,8 @@ object Manifest {
     val defaultRef: String = "default"
   }
 
-  final case class Volume(
-    name: String,
-    mountPath: Path,
-    volumeType: VolumeType
-  )
-
-  sealed abstract class VolumeType extends Product with Serializable
-
-  object VolumeType {
-    final case class EmptyDirectory(sizeInMb: Int) extends VolumeType
-  }
+  /** An empty scratch volume to be mounted onto a container */
+  final case class Volume(name: String, mountPath: Path, size: Int)
 
   final case class AlertOptOut(ref: String)
 

--- a/core/src/main/scala/StubbedConsulClient.scala
+++ b/core/src/main/scala/StubbedConsulClient.scala
@@ -1,0 +1,25 @@
+package nelson
+
+import cats.~>
+import cats.effect.IO
+
+import helm.ConsulOp
+
+import scala.collection.immutable.Set
+
+object StubbedConsulClient extends (ConsulOp ~> IO) {
+  def apply[A](fa: ConsulOp[A]): IO[A] = fa match {
+    case ConsulOp.KVGet(key) => IO.pure(None)
+    case ConsulOp.KVSet(key, value) => IO.unit
+    case ConsulOp.KVListKeys(prefix) => IO.pure(Set.empty)
+    case ConsulOp.KVDelete(key) => IO.unit
+    case ConsulOp.HealthListChecksForService(service, datacenter, near, nodeMeta) => IO.pure(List.empty)
+    case ConsulOp.HealthListChecksForNode(node, datacenter) => IO.pure(List.empty)
+    case ConsulOp.HealthListChecksInState(state, datacenter, near, nodeMeta) => IO.pure(List.empty)
+    case ConsulOp.HealthListNodesForService(service, datacenter, near, nodeMeta, tag, passingOnly) => IO.pure(List.empty)
+    case ConsulOp.AgentRegisterService(service, id, tags, address, port, enableTagOverride, check, checks) => IO.unit
+    case ConsulOp.AgentDeregisterService(service) => IO.unit
+    case ConsulOp.AgentListServices => IO.pure(Map.empty)
+    case ConsulOp.AgentEnableMaintenanceMode(id, enable, reason) => IO.unit
+  }
+}

--- a/core/src/test/resources/nelson/manifest.v1.everything.yml
+++ b/core/src/test/resources/nelson/manifest.v1.everything.yml
@@ -111,8 +111,7 @@ plans:
     volumes:
       - name: an-empty-dir
         mountPath: /foo/bar
-        emptyDir:
-          size: 500
+        size: 500
 
   - name: qa-crawler-1
     schedule: once

--- a/core/src/test/resources/nelson/manifest.v1.everything.yml
+++ b/core/src/test/resources/nelson/manifest.v1.everything.yml
@@ -108,6 +108,11 @@ plans:
       - ref: s3
         uri: http://s3.aws.com
     expiration_policy: retain-latest-two-major
+    volumes:
+      - name: an-empty-dir
+        mountPath: /foo/bar
+        emptyDir:
+          size: 500
 
   - name: qa-crawler-1
     schedule: once

--- a/core/src/test/scala/ConfigSpec.scala
+++ b/core/src/test/scala/ConfigSpec.scala
@@ -37,14 +37,6 @@ class ConfigSpec extends FlatSpec with Matchers {
     dcs.length should equal (2)
   }
 
-  it should "fail if consul is not specified" in {
-    val cfg = read("nelson/datacenters-missing-consul.cfg").attempt.unsafeRunSync()
-    cfg.swap.exists { err =>
-      val msg = err.getMessage
-      msg == "No such key: infrastructure.consul.endpoint"
-    } should equal (true)
-  }
-
   it should "fail if domain is not specified" in {
     val cfg = read("nelson/datacenters-missing-domain.cfg").attempt.unsafeRunSync()
     cfg.swap.exists { err =>

--- a/core/src/test/scala/Fixtures.scala
+++ b/core/src/test/scala/Fixtures.scala
@@ -164,13 +164,6 @@ object Fixtures {
       rest <- Gen.listOfN(1, genManifestPort)
     } yield Manifest.Ports(default, rest)
 
-  val genManifestVolume: Gen[Manifest.Volume] =
-    for {
-      a <- alphaNumStr
-      b <- alphaNumStr
-      c <- Gen.oneOf(Seq("rw", "r"))
-    } yield Manifest.Volume(a,b,c)
-
   val genManifestDeploymentTarget: Gen[Manifest.DeploymentTarget] =
     for {
       a <- Gen.listOfN(10, alphaNumStr)

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -84,7 +84,7 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
           alertOptOuts = List(AlertOptOut("api_high_request_latency")),
           policy = Some(RetainLatestTwoMajor),
           healthChecks = List(HealthCheck("http-status","default","https",Some("v1/status"), 10.seconds, 2.seconds)),
-          volumes = List(Volume("an-empty-dir", Paths.get("/foo/bar"), VolumeType.EmptyDirectory(500)))
+          volumes = List(Volume("an-empty-dir", Paths.get("/foo/bar"), 500))
         )
       ),
       Plan(

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -17,6 +17,8 @@
 package nelson
 package yaml
 
+import java.nio.file.Paths
+
 import org.scalatest.{FlatSpec,Matchers}
 import scala.concurrent.duration._
 import cats.instances.either._
@@ -81,7 +83,8 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
           resources = Map("s3" -> new java.net.URI("http://s3.aws.com")),
           alertOptOuts = List(AlertOptOut("api_high_request_latency")),
           policy = Some(RetainLatestTwoMajor),
-          healthChecks = List(HealthCheck("http-status","default","https",Some("v1/status"), 10.seconds, 2.seconds))
+          healthChecks = List(HealthCheck("http-status","default","https",Some("v1/status"), 10.seconds, 2.seconds)),
+          volumes = List(Volume("an-empty-dir", Paths.get("/foo/bar"), VolumeType.EmptyDirectory(500)))
         )
       ),
       Plan(

--- a/http/build.sbt
+++ b/http/build.sbt
@@ -68,7 +68,7 @@ prometheusVersion := sys.env.getOrElse("PROMETHEUS_VERSION", "1.4.1")
 
 dockerCommands ++= Seq(
   ExecCmd("RUN", "addgroup", "nelson"),
-  ExecCmd("RUN", "adduser", "-s", "/bin/false", "-G", "nelson", "-S", "-D", "-H", "nelson"),
+  ExecCmd("RUN", "adduser", "-s", "/bin/false", "-u", "1000", "-G", "nelson", "-S", "-D", "-H", "nelson"),
   ExecCmd("RUN", "ln", "-s", s"${(defaultLinuxInstallLocation in Docker).value}/bin/${normalizedName.value}", "/usr/local/bin/sbt"),
   ExecCmd("RUN", "chmod", "555", s"${(defaultLinuxInstallLocation in Docker).value}/bin/${normalizedName.value}"),
   ExecCmd("RUN", "chown", "-R", "nelson:nelson", s"${(defaultLinuxInstallLocation in Docker).value}"),
@@ -86,6 +86,8 @@ dockerCommands ++= {
     ExecCmd("RUN", "rm", "-rf", s"/tmp/${prometheusBase}", s"/tmp/${prometheusBase}.tar.gz")
   )
 }
+
+dockerCommands += Cmd("USER", "1000")
 
 scalaTestVersion := "3.0.5"
 


### PR DESCRIPTION
Initially started as just implementing volume mounts, but added some other stuff too..

- Add support for empty "scratch" directory volume mounts
- Add support for K8s 1.9.x and 1.10.x
- Allow operators to choose between in or out of cluster - if deploying in-cluster it will assuming the appropriate RBAC is configured and use Pod-mounted certs
- Build image to run as non-root
- Stub Consul client in K8s mode so we don't get bogus Consul errors in logs