### PR TITLE
Kubernetes/jwt

### DIFF
--- a/core/src/main/scala/InstrumentedVaultClient.scala
+++ b/core/src/main/scala/InstrumentedVaultClient.scala
@@ -52,6 +52,7 @@ class InstrumentedVaultClient private (instance: String, interp: Vault ~> IO, me
     case _: CreatePolicy => "createPolicy"
     case _: DeletePolicy => "deletePolicy"
     case _: CreateToken => "createToken"
+    case _: CreateKubernetesRole => "createKubernetesRole"
   }
 }
 

--- a/core/src/main/scala/Templates.scala
+++ b/core/src/main/scala/Templates.scala
@@ -35,6 +35,7 @@ import scala.concurrent.duration._
 import Datacenter.StackName
 import Nelson.NelsonK
 import Metrics.default.{consulTemplateContainerCleanupFailuresTotal, consulTemplateContainersRunning, consulTemplateRunsDurationSeconds, consulTemplateRunsFailuresTotal}
+import vault.policies
 
 object Templates {
   import java.util.concurrent.ScheduledExecutorService

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -24,7 +24,7 @@ import nelson.docker.DockerOp
 import nelson.logging.LoggingOp
 import nelson.scheduler.SchedulerOp
 import nelson.storage.{StoreOp}
-import nelson.vault.Vault
+import nelson.vault.{Vault,policies}
 
 import cats.data.{EitherK, OptionT}
 import cats.free.Free

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -135,6 +135,20 @@ object Workflow {
     def deletePolicyFromVault(sn: StackName, ns: NamespaceName): WorkflowF[Unit] =
       policies.deletePolicy(sn, ns).inject
 
+    /*
+     * Here we are essentially doing the equivilent of the following vault
+     * CLI execution:
+     *
+     * vault write auth/<cluster>/role/<stackname> \
+     *   bound_service_account_names=<stackname> \
+     *   bound_service_account_namespaces=<namespace> \
+     *   policies=<stackname>
+     */
+    def writeKubernetesRoleToVault(dc: Datacenter, sn: StackName, ns: NamespaceName): WorkflowF[Unit] =
+      Vault.createKubernetesRole(sn.toString, dc.name,
+          List(sn.toString), List(ns.asString),
+          None, None, Some(List(sn.toString))).inject
+
     def writeDiscoveryToConsul(id: ID, sn: StackName, ns: NamespaceName, dc: Datacenter): WorkflowF[Unit] =
       for {
         d  <- StoreOp.getDeployment(id).inject[WorkflowOp]
@@ -182,5 +196,8 @@ object Workflow {
         _ <- handleDockerLogs(c) { case e: PushError => e }
       } yield b._2
     }
+
+    def vaultLoggingFields(sn: Datacenter.StackName, ns: NamespaceName, dcName: String): String =
+      s"namespace=${ns} unit=${sn.serviceType} policy=${vault.policies.policyName(sn, ns)} datacenter=${dcName}"
   }
 }

--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -46,17 +46,18 @@ final class Http4sVaultClient(authToken: Token,
   val v1BaseUri = baseUri / "v1"
 
   def apply[A](v: Vault[A]): IO[A] = v match {
-    case IsInitialized          => isInitialized
-    case Initialize(init)       => initialize(init)
-    case GetSealStatus          => sealStatus
-    case Seal                   => seal
-    case Unseal(key)            => unseal(key)
-    case Get(path)              => get(path)
-    case Set(path, value)       => put(path,value)
-    case cp @ CreatePolicy(_,_) => createPolicy(cp)
-    case DeletePolicy(name)     => deletePolicy(name)
-    case GetMounts              => getMounts
-    case ct: CreateToken        => createToken(ct)
+    case IsInitialized            => isInitialized
+    case Initialize(init)         => initialize(init)
+    case GetSealStatus            => sealStatus
+    case Seal                     => seal
+    case Unseal(key)              => unseal(key)
+    case Get(path)                => get(path)
+    case Set(path, value)         => put(path,value)
+    case cp @ CreatePolicy(_,_)   => createPolicy(cp)
+    case DeletePolicy(name)       => deletePolicy(name)
+    case GetMounts                => getMounts
+    case ct: CreateToken          => createToken(ct)
+    case kr: CreateKubernetesRole => createKubernetesRole(kr)
   }
 
   val log = Logger[this.type]
@@ -133,4 +134,7 @@ final class Http4sVaultClient(authToken: Token,
         case None => IO.raiseError(new RuntimeException("No auth/client_token in create token response"))
       }
     }
+
+  def createKubernetesRole(ckr: CreateKubernetesRole): IO[Unit] =
+    reqVoid(Request(POST, v1BaseUri / "auth" / ckr.authClusterName / "role" / ckr.roleName).withBody(ckr.asJson))
 }

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -105,7 +105,7 @@ trait Json {
     jEmptyObject
   }
 
-  implicit val jsonCreateKubernetesRole: EncodeJson[CreateKubernetesRole] = 
+  implicit val jsonCreateKubernetesRole: EncodeJson[CreateKubernetesRole] =
     EncodeJson { kr =>
       ("bound_service_account_names" := kr.serviceAccountNames) ->:
       ("bound_service_account_namespaces" := kr.seviceAccountNamespaces) ->:

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -104,4 +104,14 @@ trait Json {
     ("num_uses" := ct.numUses) ->:
     jEmptyObject
   }
+
+  implicit val jsonCreateKubernetesRole: EncodeJson[CreateKubernetesRole] = 
+    EncodeJson { kr =>
+      ("bound_service_account_names" := kr.serviceAccountNames) ->:
+      ("bound_service_account_namespaces" := kr.seviceAccountNamespaces) ->:
+      ("ttl" :?= kr.defaultLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
+      ("max_ttl" :?= kr.maxLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
+      ("policies" :?= kr.policies) ->?:
+      jEmptyObject
+    }
 }

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -110,6 +110,21 @@ object Vault {
     numUses: Long = 0L
   ): VaultF[Token] = Free.liftF(CreateToken(policies, renewable, ttl, numUses))
 
+  def createKubernetesRole(
+    roleName: String,
+    authClusterName: String,
+    serviceAccountNames: List[String],
+    seviceAccountNamespaces: List[String],
+    defaultLeaseTTL: Option[FiniteDuration],
+    maxLeaseTTL: Option[FiniteDuration],
+    policies: Option[List[String]]
+  ): VaultF[Unit] = Free.liftF(CreateKubernetesRole(
+    roleName, authClusterName,
+    serviceAccountNames,
+    seviceAccountNamespaces,
+    defaultLeaseTTL, maxLeaseTTL,
+    policies))
+
   case object IsInitialized extends Vault[Boolean]
   final case class Initialize(init: Initialization) extends Vault[InitialCreds]
   final case class Unseal(key: MasterKey) extends Vault[SealStatus]
@@ -121,5 +136,13 @@ object Vault {
   final case class CreatePolicy(name: String, rules: List[Rule]) extends Vault[Unit]
   final case class DeletePolicy(name: String) extends Vault[Unit]
   final case class CreateToken(policies: Option[List[String]], renewable: Boolean, ttl: Option[FiniteDuration], numUses: Long = 0L) extends Vault[Token]
+  final case class CreateKubernetesRole(
+    authClusterName: String,
+    roleName: String,
+    serviceAccountNames: List[String],
+    seviceAccountNamespaces: List[String],
+    defaultLeaseTTL: Option[FiniteDuration],
+    maxLeaseTTL: Option[FiniteDuration],
+    policies: Option[List[String]]) extends Vault[Unit]
 }
 

--- a/core/src/main/scala/vault/policies.scala
+++ b/core/src/main/scala/vault/policies.scala
@@ -15,6 +15,7 @@
 //:
 //: ----------------------------------------------------------------------------
 package nelson
+package vault
 
 import nelson.Datacenter.StackName
 
@@ -23,9 +24,7 @@ import cats.effect.IO
 
 import fs2.Stream
 
-import vault._
-
-package object policies {
+object policies {
 
   val DenySysRule =
     Rule("sys/*", policy = Some("deny"), capabilities = Nil)

--- a/core/src/main/scala/workflows/Magnetar.scala
+++ b/core/src/main/scala/workflows/Magnetar.scala
@@ -77,7 +77,4 @@ object Magnetar extends Workflow[Unit] {
     delete(dc,d) *>
     status(d.id, Terminated, s"Decommissioning deployment ${sn} in ${dc.name}")
   }
-
-  private def vaultLoggingFields(sn: Datacenter.StackName, ns: NamespaceName, dcName: String): String =
-    s"namespace=${ns} unit=${sn.serviceType} policy=${vault.policies.policyName(sn, ns)} datacenter=${dcName}"
 }

--- a/core/src/main/scala/workflows/Magnetar.scala
+++ b/core/src/main/scala/workflows/Magnetar.scala
@@ -79,5 +79,5 @@ object Magnetar extends Workflow[Unit] {
   }
 
   private def vaultLoggingFields(sn: Datacenter.StackName, ns: NamespaceName, dcName: String): String =
-    s"namespace=${ns} unit=${sn.serviceType} policy=${policies.policyName(sn, ns)} datacenter=${dcName}"
+    s"namespace=${ns} unit=${sn.serviceType} policy=${vault.policies.policyName(sn, ns)} datacenter=${dcName}"
 }

--- a/core/src/test/scala/NelsonSuite.scala
+++ b/core/src/test/scala/NelsonSuite.scala
@@ -104,6 +104,7 @@ trait NelsonSuite
       case Vault.DeletePolicy(_) => ()
       case Vault.GetMounts => SortedMap.empty
       case _: Vault.CreateToken => vault.Token("aaaaaaaa-bbbb-cccc-dddddddddddd")
+      case _: Vault.CreateKubernetesRole => ()
     })
   }
 

--- a/core/src/test/scala/vault/PoliciesSpec.scala
+++ b/core/src/test/scala/vault/PoliciesSpec.scala
@@ -15,11 +15,11 @@
 //:
 //: ----------------------------------------------------------------------------
 package nelson
+package vault
 
 import org.scalatest.{Matchers,FlatSpec,Inspectors}
 import policies._
 import nelson.test._
-import vault._
 
 import cats.effect.IO
 


### PR DESCRIPTION
This adds support for the Vault kubernetes auth mechinism:
https://www.vaultproject.io/api/auth/kubernetes/index.html

Here, Nelson is simply taking the policies it provisioned per-stack, and enabling vault to use the stack-specific JWT to authenticate against Vault. In order to do this, the following administrator steps are required:

1. Create a service account in kubernetes that will be used for token validation 

```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vault-auth
  namespace: default
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRoleBinding
metadata:
  name: role-tokenreview-binding
  namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:auth-delegator
subjects:
- kind: ServiceAccount
  name: vault-auth
  namespace: default
```

2. submit this to kubernetes:

```
kubectl apply -f /path/to/above.yml
```
3. Next configure Vault to have the auth backend:

```
# fetch the JWT token
stack_name=vault-auth
token_name=$(kubectl -n default get serviceaccount vault-auth -o jsonpath='{.secrets[0].name}')
token_data=$(kubectl get secret "${token_name}" -o jsonpath='{.data.token}' | base64 --decode)

# setup a principle for this JWT
vault write auth/kubernetes/config \
token_reviewer_jwt="${token_data}" \
kubernetes_host=$KUBEURL \
kubernetes_ca_cert=@/path/to/ca
```

4. At runtime, from within the deployed pod (an application deployed with Nelson), do something like this in your container (or init container):

```
# fetch the JWT token
token_data=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)

vault write -format=json -address="${VAULT_ADDR}" \
"auth/kubernetes/login" \
role="${NELSON_STACK}" \
jwt="${token_data}"
```