### PR TITLE
Change the default nelson UID inside the container

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -69,10 +69,6 @@ nelson {
     # fix this value.
     key-id = 468513861
 
-    # IMPORTANT: you must specify a value for this
-    # entropy used for the creation of encryption hmac and encryption
-    # blob = "be-sure-to-change-this"
-
     # for development sometimes we want to not have to actually log in
     # with github. when set to `true` this will force the system to "auto-auth"
     # the system based on local environment variables. This really is for
@@ -260,6 +256,7 @@ nelson {
   #       vault {
   #         endpoint   = "https://vault.service.texas.your.company.com:1234"
   #         auth-token = "XXXXXXXXX"
+  #         timeout    = 5 seconds
   #       }
   #
   #       loadbalancer {

--- a/http/build.sbt
+++ b/http/build.sbt
@@ -71,7 +71,7 @@ prometheusVersion := sys.env.getOrElse("PROMETHEUS_VERSION", "1.4.1")
 
 dockerCommands ++= Seq(
   ExecCmd("RUN", "addgroup", "nelson"),
-  ExecCmd("RUN", "adduser", "-s", "/bin/false", "-u", "1000", "-G", "nelson", "-S", "-D", "-H", "nelson"),
+  ExecCmd("RUN", "adduser", "-s", "/bin/false", "-u", "2000", "-G", "nelson", "-S", "-D", "-H", "nelson"),
   ExecCmd("RUN", "ln", "-s", s"${(defaultLinuxInstallLocation in Docker).value}/bin/${normalizedName.value}", "/usr/local/bin/sbt"),
   ExecCmd("RUN", "chmod", "555", s"${(defaultLinuxInstallLocation in Docker).value}/bin/${normalizedName.value}"),
   ExecCmd("RUN", "chown", "-R", "nelson:nelson", s"${(defaultLinuxInstallLocation in Docker).value}"),
@@ -80,7 +80,7 @@ dockerCommands ++= Seq(
 
 // Install kubectl for the Kubernetes scheduler implementation
 dockerCommands ++= Seq(
-  ExecCmd("RUN", "wget", "--retry-connrefused", "--waitretry", "1", "--read-timeout", "10", "--timeout", "15", "-t", "5", s"https://storage.googleapis.com/kubernetes-release/release/v${kubectlVersion.value}/bin/linux/amd64/kubectl", "-P", "/usr/local/bin"),
+  ExecCmd("RUN", "wget", "-nv", "--retry-connrefused", "--waitretry", "1", "--read-timeout", "10", "--timeout", "15", "-t", "5", s"https://storage.googleapis.com/kubernetes-release/release/v${kubectlVersion.value}/bin/linux/amd64/kubectl", "-P", "/usr/local/bin"),
   ExecCmd("RUN", "chmod", "+x", "/usr/local/bin/kubectl")
 )
 
@@ -88,7 +88,7 @@ dockerCommands ++= Seq(
 dockerCommands ++= {
   val prometheusBase = s"prometheus-${prometheusVersion.value}.linux-amd64"
   Seq(
-    ExecCmd("RUN", "wget", "--retry-connrefused", "--waitretry", "1", "--read-timeout", "10", "--timeout", "15", "-t", "5", s"https://github.com/prometheus/prometheus/releases/download/v${prometheusVersion.value}/${prometheusBase}.tar.gz", "-P", "/tmp"),
+    ExecCmd("RUN", "wget", "-nv", "--retry-connrefused", "--waitretry", "1", "--read-timeout", "10", "--timeout", "15", "-t", "5", s"https://github.com/prometheus/prometheus/releases/download/v${prometheusVersion.value}/${prometheusBase}.tar.gz", "-P", "/tmp"),
     ExecCmd("RUN", "tar", "xzf", s"/tmp/${prometheusBase}.tar.gz", "-C", "/tmp"),
     ExecCmd("RUN", "ls", "/tmp"),
     ExecCmd("RUN", "cp", s"/tmp/${prometheusBase}/promtool", "/usr/local/bin"),
@@ -96,7 +96,7 @@ dockerCommands ++= {
   )
 }
 
-dockerCommands += Cmd("USER", "1000")
+dockerCommands += Cmd("USER", "2000")
 
 scalaTestVersion := "3.0.5"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@
 //: ----------------------------------------------------------------------------
 resolvers += "bintray sbt" at "https://dl.bintray.com/sbt/sbt-plugin-releases/"
 
-addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"  % "1.3.2")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"  % "1.3.9")
 
 addSbtPlugin("io.get-coursier"   % "sbt-coursier"         % "1.0.0")
 


### PR DESCRIPTION
Previously the `nelson` user was set to UID `1000`, which tends to be the default admin user on a given OS. This is strictly not safe as we want to be very explicit about how we map permissions. When using the nelson container, it is typical that people should create a service account on the OS that maps to a privileged user; something like:

```
# make a nelson user
sudo useradd -r -s /bin/false -u 2000 nelson
# lock the account from further modification
sudo usermod -L nelson
```
