### PR TITLE
blueprints/manifest

### DIFF
--- a/core/src/main/scala/Actionable.scala
+++ b/core/src/main/scala/Actionable.scala
@@ -49,7 +49,7 @@ object Actionable {
   /*
    * A Versioned UnitDef Actionable runs a prescribed Workflow, which will
    * launch the unit into a given datacenter using a scheduler such as
-   * Nomad.
+   * Nomad or Kubernetes.
    */
   implicit val UnitDefActionable = new Actionable[UnitDef @@ Versioned] {
     import Manifest.{Namespace,Plan}

--- a/core/src/main/scala/Exceptions.scala
+++ b/core/src/main/scala/Exceptions.scala
@@ -224,7 +224,6 @@ object YamlError {
   def invalidMemoryBound(request: Double, limit: Double): YamlError = InvalidMemoryBound(request, limit)
   val missingMemoryLimit: YamlError = MissingMemoryLimit
   def invalidInstances(d: Int): YamlError = InvalidInstances(d)
-  def invalidEphemeralDisk(min: Int, max: Int, request: Int): YamlError = InvalidEphemeralDisk(min, max, request)
   def invalidTrafficShiftPolicy(name: String): YamlError = InvalidTrafficShift(name)
   def invalidTrafficShiftDuration(dur: String): YamlError = InvalidTrafficShiftDuration(dur)
   def invalidNamespace(n: String, reason: String): YamlError = InvalidNamespace(n,reason)
@@ -332,9 +331,6 @@ private final case object MissingMemoryLimit
 
 private final case class InvalidInstances(d: Int)
     extends YamlError(s"$d is an invalid instances request, must be between 0 and 500")
-
-private final case class InvalidEphemeralDisk(min: Int, max: Int, request: Int)
-    extends YamlError(s"$request is an invalid ephemeral disk request, must be between $min and $max")
 
 private final case class InvalidTrafficShift(name: String)
   extends YamlError(s"'$name' is not a valid traffic shift policy.")

--- a/core/src/main/scala/Exceptions.scala
+++ b/core/src/main/scala/Exceptions.scala
@@ -183,6 +183,9 @@ final case class InvalidUnitNameLength(name: String)
 final case class InvalidUnitNameChars(name: String)
   extends NelsonError(s"$name contains invalid characters. Unit names can only include hyphens, A-Z, a-z, 0-9 where the unit name starts and ends with an alpha-numeric character.")
 
+final case class UnknownBlueprintReference(ref: String, revision: blueprint.Blueprint.Revision)
+  extends NelsonError(s"the blueprint '${ref}@${revision.toString}' does not exist in the database; be sure you have specified the correct name and revision")
+
 final object NomadNotImplemented extends NelsonError(s"Nelson 0.11.x+ currently does not support Nomad. If you are interested in using Nelson with Nomad please file an issue on GitHub: https://github.com/getnelson/nelson/ or reach out to us on Gitter: https://gitter.im/getnelson/nelson")
 
 ////////////////////////// YAML ERRORS ///////////////////////////////

--- a/core/src/main/scala/Exceptions.scala
+++ b/core/src/main/scala/Exceptions.scala
@@ -231,7 +231,11 @@ object YamlError {
   def invalidMountPath(path: String, reason: String): YamlError = InvalidMountPath(path, reason)
   val missingVolumeSize: YamlError = MissingVolumeSize
   def invalidVolumeSize(request: Int): YamlError = InvalidVolumeSize(request)
+  def invalidBlueprintReference(blueprintRef: String): YamlError = InvalidBlueprintReference(blueprintRef)
 }
+
+private final case class InvalidBlueprintReference(ref: String)
+  extends YamlError(s"specified blueprint reference '${ref}' is not valid. Must be of the form thing@HEAD or thing@3")
 
 private final case class InvalidExternalAddress(uri: String)
   extends YamlError(s"specified uri '$uri' is not a valid URI. Must be of the form: protocol://host:port")

--- a/core/src/main/scala/Manifest.scala
+++ b/core/src/main/scala/Manifest.scala
@@ -20,6 +20,7 @@ import nelson.Manifest._
 import nelson.cleanup.ExpirationPolicy
 import nelson.notifications.NotificationSubscriptions
 import nelson.storage.StoreOp
+import nelson.blueprint.Blueprint
 
 import cats.{~>, Foldable, Monoid}
 import cats.data.{Kleisli, NonEmptyList, ValidatedNel}
@@ -116,7 +117,9 @@ object Manifest {
     policy: Option[ExpirationPolicy] = None,
     trafficShift: Option[TrafficShift] = None,
     volumes: List[Volume] = List.empty,
-    ephemeralDisk: Option[Int] = None
+    ephemeralDisk: Option[Int] = None,
+    workflow: Option[Workflow[Unit]] = None,
+    blueprint: Option[Either[BlueprintRef, Blueprint]] = None
   )
 
   final case class Namespace(

--- a/core/src/main/scala/Manifest.scala
+++ b/core/src/main/scala/Manifest.scala
@@ -64,7 +64,7 @@ object Manifest {
   )
 
   object Plan {
-    val default = Plan("default", Environment(workflow = Magnetar))
+    val default = Plan("default", Environment(workflow = Pulsar))
   }
 
   sealed abstract class ResourceSpec extends Product with Serializable {
@@ -110,7 +110,6 @@ object Manifest {
     policy: Option[ExpirationPolicy] = None,
     trafficShift: Option[TrafficShift] = None,
     volumes: List[Volume] = List.empty,
-    ephemeralDisk: Option[Int] = None,
     workflow: Workflow[Unit] = Magnetar,
     blueprint: Option[Either[BlueprintRef, Blueprint]] = None
   )

--- a/core/src/main/scala/ManifestValidator.scala
+++ b/core/src/main/scala/ManifestValidator.scala
@@ -185,8 +185,6 @@ object ManifestValidator {
       ().validNel
     }
 
-  // def validatePlanBlueprint(b: Either[BlueprintRef, Blueprint]): Valid[]
-
   def validateUnit(unit: UnitDef, plan: Plan): IO[Valid[Unit]] =
     for {
       a <- validateAlerts(unit, plan)
@@ -195,7 +193,6 @@ object ManifestValidator {
       d <- IO.pure(validatePeriodic(unit,plan))
       e <- IO.pure(validateUnitNameLength(unit))
       f <- IO.pure(validateUnitNameChars(unit))
-      // g <- validateBlueprint
     } yield (a combine b combine c combine d combine e combine f)
 
   def parseManifestAndValidate(str: String, cfg: NelsonConfig): IO[Valid[Manifest]] = {

--- a/core/src/main/scala/ManifestValidator.scala
+++ b/core/src/main/scala/ManifestValidator.scala
@@ -255,8 +255,7 @@ object ManifestValidator {
         a <- foooo
         b  = Foldable[List].fold(a.map(_.map(_ => ())))
         c  = a.traverse(_.toList).flatMap(identity)
-        d <- IO.pure((b, c))
-      } yield d
+      } yield (b, c)
     }
 
     def validate(m: Manifest): IO[Valid[Manifest]] = {

--- a/core/src/main/scala/ManifestValidator.scala
+++ b/core/src/main/scala/ManifestValidator.scala
@@ -228,7 +228,7 @@ object ManifestValidator {
     }
 
     def validateBlueprints(m: Manifest): IO[(Valid[Unit], List[Plan])] = {
-      val foooo: IO[List[Valid[Plan]]] = m.plans.foldLeft(IO.pure(List.empty[Valid[Plan]])) { (res, plan) =>
+      val plans: IO[List[Valid[Plan]]] = m.plans.foldLeft(IO.pure(List.empty[Valid[Plan]])) { (res, plan) =>
         val result: IO[Valid[Plan]] = plan.environment.blueprint match {
           // supplied manifest held a manifest reference
           case Some(Left((ref,revision))) => {
@@ -254,7 +254,7 @@ object ManifestValidator {
       for {
         a <- plans
         b  = Foldable[List].fold(a.map(_.map(_ => ())))
-        c  = a.flatTraverse(_.toList)
+        c  = a.traverse(_.toList).flatMap(identity)
       } yield (b, c)
     }
 

--- a/core/src/main/scala/ManifestValidator.scala
+++ b/core/src/main/scala/ManifestValidator.scala
@@ -252,9 +252,9 @@ object ManifestValidator {
       }
 
       for {
-        a <- foooo
+        a <- plans
         b  = Foldable[List].fold(a.map(_.map(_ => ())))
-        c  = a.traverse(_.toList).flatMap(identity)
+        c  = a.flatTraverse(_.toList)
       } yield (b, c)
     }
 

--- a/core/src/main/scala/Nelson.scala
+++ b/core/src/main/scala/Nelson.scala
@@ -244,17 +244,19 @@ object Nelson {
       g   <- fetchRelease(e)
       v   <- fetchRepoManifestAndValidateDeployable(e.slug, g.tagName)
       m   <- Kleisli.liftF(v.fold(e => IO.raiseError(MultipleValidationErrors(e)), m => IO.pure(m)))
+      // take the deployable and modify the manifest to incorporate the release info
       ms  <- Kleisli.liftF(Manifest.saturateManifest(m)(g))
     } yield ms
   }
 
-  private def fetchRelease(e: Github.ReleaseEvent): NelsonK[Github.Release] = Kleisli { cfg =>
-    val t = cfg.git.systemAccessToken
+  private def fetchRelease(e: Github.ReleaseEvent): NelsonK[Github.Release] =
+    Kleisli { cfg =>
+      val t = cfg.git.systemAccessToken
 
-    Github.Request.fetchRelease(e.slug, e.id)(t).foldMap(cfg.github)
-      .ensure(MissingReleaseAssets(e))(_.assets.nonEmpty)
-      .retryExponentially(2.seconds, 3)(cfg.pools.schedulingPool, cfg.pools.defaultExecutor)
-  }
+      Github.Request.fetchRelease(e.slug, e.id)(t).foldMap(cfg.github)
+        .ensure(MissingReleaseAssets(e))(_.assets.nonEmpty)
+        .retryExponentially(2.seconds, 3)(cfg.pools.schedulingPool, cfg.pools.defaultExecutor)
+    }
 
   def deploy(actions: List[Manifest.Action]): NelsonK[Unit] =
     Kleisli(cfg => actions.traverse_(a => cfg.queue.enqueue1(a)))

--- a/core/src/main/scala/Nelson.scala
+++ b/core/src/main/scala/Nelson.scala
@@ -378,7 +378,6 @@ object Nelson {
           Map("database" -> FeatureVersion(1,2)),
           Set.empty,
           Alerting.empty,
-          Magnetar,
           Some(Ports(Port("default", 1, "http"), Nil)),
           Some(Deployable(unitName, version, Deployable.Container(image.toString))),
           Set("some-tag")

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -18,7 +18,6 @@ package nelson
 
 import nelson.Datacenter.{Deployment}
 import nelson.Manifest.{UnitDef,Versioned,Plan,AlertOptOut}
-import nelson.blueprint.Template
 import nelson.docker.Docker.Image
 import nelson.docker.DockerOp
 import nelson.logging.LoggingOp
@@ -93,8 +92,8 @@ object Workflow {
     def pure[A](a: => A): WorkflowF[A] =
       WorkflowControlOp.pure(a).inject
 
-    def launch(i: Image, dc: Datacenter, ns: NamespaceName, u: UnitDef @@ Versioned, p: Plan, blueprint: Option[Template], hash: String): WorkflowF[String] =
-      SchedulerOp.launch(i, dc, ns, u, p, blueprint, hash).inject
+    def launch(i: Image, dc: Datacenter, ns: NamespaceName, u: UnitDef @@ Versioned, p: Plan, hash: String): WorkflowF[String] =
+      SchedulerOp.launch(i, dc, ns, u, p, hash).inject
 
     def delete(dc: Datacenter, d: Deployment): WorkflowF[Unit] =
       SchedulerOp.delete(dc,d).inject
@@ -158,7 +157,6 @@ object Workflow {
       } yield ()
 
     def createTrafficShift(id: ID, nsRef: NamespaceName, dc: Datacenter, p: TrafficShiftPolicy, dur: FiniteDuration): WorkflowF[Unit] = {
-
       val prog = for {
         ns   <- OptionT(StoreOp.getNamespace(dc.name, nsRef))
         to   <- OptionT(StoreOp.getDeployment(id).map(Option(_)))

--- a/core/src/main/scala/blueprint/Blueprint.scala
+++ b/core/src/main/scala/blueprint/Blueprint.scala
@@ -38,11 +38,14 @@ object Blueprint {
   /**
    * We will serialize references to blueprints with a simple delimited string:
    * {{{
-   * # specifically fix to the 123 version of the `foo-bar` blueprint
+    *
+   * ==>> specifically fix to the 123 version of the `foo-bar` blueprint
    * foo-bar@123
-   * # uses the latest (whatever revision that is) of a specified blueprint
+   *
+   * ==>> uses the latest (whatever revision that is) of a specified blueprint
    * use-gpu-hardware@HEAD
-   * # equivilent to HEAD
+   *
+   * ==>> equivilent to HEAD
    * do-my-bidding
    * }}}
    */

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -44,6 +44,7 @@ package object nelson {
   type DeploymentHash = String
   type TempoaryAccessCode = String
   type WorkflowRef = String
+  type BlueprintRef = (String, blueprint.Blueprint.Revision)
   type DatacenterRef = String
   type StatusMessage = String
   type DependencyEdge = (routing.RoutingNode, routing.RoutingNode)

--- a/core/src/main/scala/scheduler/NomadHttp.scala
+++ b/core/src/main/scala/scheduler/NomadHttp.scala
@@ -391,7 +391,6 @@ object NomadJson {
             "Name"          := name,
             "Count"         := env.desiredInstances.getOrElse(1),
             "RestartPolicy" := env.retries.map(restartJson).getOrElse(restartJson(3)), // if no retry specified, only try 3 times rather than 15.
-            "EphemeralDisk" := ephemeralDiskJson(false,false,plan.environment.ephemeralDisk.getOrElse(101)),
             "Tasks"         := List(leaderTaskJson(name,unitName,i,env,BridgeMode,ports,nomad,ns,plan.name, tags))
           )
         )

--- a/core/src/main/scala/scheduler/NomadHttp.scala
+++ b/core/src/main/scala/scheduler/NomadHttp.scala
@@ -20,7 +20,6 @@ package scheduler
 import nelson.Datacenter.{Deployment, StackName}
 import nelson.Json._
 import nelson.Manifest.{Environment, EnvironmentVariable, HealthCheck, Plan, Port, Ports, UnitDef}
-import nelson.blueprint.Template
 import nelson.docker.Docker
 import nelson.docker.Docker.Image
 
@@ -59,9 +58,9 @@ final class NomadHttp(
     co match {
       case Delete(dc,d) =>
         deleteUnitAndChildren(dc, d).retryExponentially()(scheduler, ec)
-      case Launch(i, dc, ns, u, p, blueprint, hash) =>
+      case Launch(i, dc, ns, u, p, hash) =>
         val unit = Manifest.Versioned.unwrap(u)
-        launch(unit, hash, u.version, i, dc, ns, p, blueprint).retryExponentially()(scheduler, ec)
+        launch(unit, hash, u.version, i, dc, ns, p).retryExponentially()(scheduler, ec)
       case Summary(dc,_,sn) =>
         summary(dc,sn)
     }
@@ -132,8 +131,11 @@ final class NomadHttp(
   private def buildName(sn: StackName): String =
     cfg.applicationPrefix.map(prefix => s"${prefix}-${sn.toString}").getOrElse(sn.toString)
 
-  private def launch(u: UnitDef, hash: String, version: Version, img: Image, dc: Datacenter, ns: NamespaceName, plan: Plan, blueprint: Option[Template]): IO[String] =
-    blueprint.fold(launchDefault(u, hash, version, img, dc, ns, plan)) { template =>
+  private def launch(u: UnitDef, hash: String, version: Version, img: Image, dc: Datacenter, ns: NamespaceName, plan: Plan): IO[String] =
+    plan.environment.blueprint
+      .flatMap(_.right.toOption)
+      .map(_.template)
+      .fold(launchDefault(u, hash, version, img, dc, ns, plan)) { template =>
       launchDefault(u, hash, version, img, dc, ns, plan)
       val sn = StackName(u.name, version, hash)
       val name = buildName(sn)

--- a/core/src/main/scala/scheduler/SchedulerOp.scala
+++ b/core/src/main/scala/scheduler/SchedulerOp.scala
@@ -17,7 +17,6 @@
 package nelson
 package scheduler
 
-import nelson.blueprint.Template
 import nelson.docker.Docker.Image
 import nelson.Manifest.{Plan, UnitDef, Versioned}
 
@@ -29,14 +28,14 @@ object SchedulerOp {
 
   final case class Delete(dc: Datacenter, d: Datacenter.Deployment) extends SchedulerOp[Unit]
 
-  final case class Launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, blueprint: Option[Template], hash: String) extends SchedulerOp[String]
+  final case class Launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String) extends SchedulerOp[String]
 
   final case class Summary(dc: Datacenter, ns: NamespaceName, sn: Datacenter.StackName) extends SchedulerOp[Option[DeploymentSummary]]
 
   type SchedulerF[A] = Free[SchedulerOp, A]
 
-  def launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, blueprint: Option[Template], hash: String): SchedulerF[String] =
-    Free.liftF(Launch(i, dc, ns, a, p, blueprint, hash))
+  def launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String): SchedulerF[String] =
+    Free.liftF(Launch(i, dc, ns, a, p, hash))
 
   def delete(dc: Datacenter, d: Datacenter.Deployment): SchedulerF[Unit] =
     Free.liftF(Delete(dc,d))

--- a/core/src/main/scala/workflows/Canopus.scala
+++ b/core/src/main/scala/workflows/Canopus.scala
@@ -37,7 +37,7 @@ object Canopus extends Workflow[Unit] {
       i <- DockerOp.extract(Versioned.unwrap(vunit)).inject[WorkflowOp]
       _ <- status(id, Pending, "Canopus workflow about to start")
       _ <- logToFile(id, s"Instructing ${dc.name}'s scheduler to handle service container")
-      l <- launch(i, dc, ns.name, vunit, p, None, hash)
+      l <- launch(i, dc, ns.name, vunit, p, hash)
       _ <- debug(s"Scheduler responded with: ${l}")
       _ <- status(id, getStatus(Manifest.Versioned.unwrap(vunit), p), "=====> Canopus workflow completed <=====")
     } yield ()

--- a/core/src/main/scala/workflows/Magnetar.scala
+++ b/core/src/main/scala/workflows/Magnetar.scala
@@ -58,7 +58,7 @@ object Magnetar extends Workflow[Unit] {
       _  <- writeDiscoveryToConsul(id, sn, ns.name, dc)
       _  <- getTrafficShift.fold(pure(()))(ts => createTrafficShift(id, ns.name, dc, ts.policy, ts.duration) *> logToFile(id, s"Creating traffic shift: ${ts.policy.ref}"))
       _  <- logToFile(id, s"instructing ${dc.name}'s scheduler to handle service container")
-      l  <- launch(i, dc, ns.name, vunit, p, None, hash)
+      l  <- launch(i, dc, ns.name, vunit, p, hash)
       _  <- debug(s"response from scheduler $l")
 
       _  <- status(id, getStatus(unit, p), "======> workflow completed <======")

--- a/core/src/main/scala/workflows/Pulsar.scala
+++ b/core/src/main/scala/workflows/Pulsar.scala
@@ -56,7 +56,7 @@ object Pulsar extends Workflow[Unit] {
       _  <- logToFile(id, s"Writing Kubernetes auth role '${sn.toString}' to Vault...")
       _  <- writeKubernetesRoleToVault(dc = dc, sn = sn, ns = ns.name)
       _ <- logToFile(id, s"Instructing ${dc.name}'s scheduler to handle service container")
-      l <- launch(i, dc, ns.name, vunit, p, None, hash)
+      l <- launch(i, dc, ns.name, vunit, p, hash)
       _ <- debug(s"Scheduler responded with: ${l}")
       _ <- status(id, getStatus(Manifest.Versioned.unwrap(vunit), p), "=====> Pulsar workflow completed <=====")
     } yield ()

--- a/core/src/main/scala/yaml/ManifestV1Parser.scala
+++ b/core/src/main/scala/yaml/ManifestV1Parser.scala
@@ -166,13 +166,7 @@ object ManifestV1Parser {
     (TrafficShiftPolicy.fromString(raw.policy).toValidNel(YamlError.invalidTrafficShiftPolicy(raw.policy)), 
       validateTrafficShiftDuration(raw.duration)).mapN(TrafficShift)
 
-  // def validateWorkflow(raw: WorkflowYaml): YamlValidation[Workflow[Unit]] =
-  //   resolveWorkflow(raw.kind)
-
   def toPlan(raw: PlanYaml): YamlValidation[Plan] = {
-    println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>.")
-    println(raw.workflow)
-    println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
     val validatedCPU =
       Option(raw.cpu).filter(_ > 0).traverse(validateCPU).andThen { cpuLimit =>
         Option(raw.cpu_request).filter(_ > 0).traverse(validateCPURequest(_, cpuLimit)).map { cpuBounds =>
@@ -187,6 +181,9 @@ object ManifestV1Parser {
         }
       }
 
+    // at this point, we do not have access to the database so we can only
+    // check that the specified blueprint is syntactically valid. The manifest
+    // validator will hydrate the reference into a Blueprint proper.
     val validateBlueprint =
       Option(raw.workflow).traverse(x =>
         Blueprint.parseNamedRevision(x.blueprint)

--- a/core/src/test/resources/nelson/manifest.v1.blueprint-missing.yml
+++ b/core/src/test/resources/nelson/manifest.v1.blueprint-missing.yml
@@ -1,0 +1,38 @@
+##: ----------------------------------------------------------------------------
+##: Copyright (C) 2017 Verizon.  All Rights Reserved.
+##:
+##:   Licensed under the Apache License, Version 2.0 (the "License");
+##:   you may not use this file except in compliance with the License.
+##:   You may obtain a copy of the License at
+##:
+##:       http://www.apache.org/licenses/LICENSE-2.0
+##:
+##:   Unless required by applicable law or agreed to in writing, software
+##:   distributed under the License is distributed on an "AS IS" BASIS,
+##:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##:   See the License for the specific language governing permissions and
+##:   limitations under the License.
+##:
+##: ----------------------------------------------------------------------------
+---
+units:
+  - name: howdy
+    description: >
+      provides the server component of the 'howdy'
+      example service, used for demo'ing nelson
+      deployment system
+    ports:
+      - default->9000/http
+
+plans:
+  - name: foo
+    workflow:
+      kind: pulsar
+      blueprint: missing-blueprint@HEAD
+
+namespaces:
+  - name: dev
+    units:
+      - ref: howdy
+        plans:
+          - foo

--- a/core/src/test/resources/nelson/manifest.v1.everything.yml
+++ b/core/src/test/resources/nelson/manifest.v1.everything.yml
@@ -25,8 +25,6 @@ units:
     dependencies:
       - ref: inventory@1.4
       - ref: cassandra@1.0
-    workflow: magnetar
-    expiration_policy: retain-active
     resources:
       - name: s3
         description: description of s3
@@ -61,8 +59,6 @@ units:
     description: crawler description
     dependencies:
       - ref: db.example@1.0
-    workflow: magnetar
-    schedule: once
     alerting:
       prometheus:
         alerts:

--- a/core/src/test/resources/nelson/manifest.v1.everything.yml
+++ b/core/src/test/resources/nelson/manifest.v1.everything.yml
@@ -154,6 +154,9 @@ plans:
       - FOO=foo-prod
       - QUX=qux-prod
     expiration_policy: retain-latest-two-feature
+    workflow:
+      kind: pulsar
+      blueprint: qux@HEAD
 
   - name: lb-plan
     instances:

--- a/core/src/test/resources/nelson/manifest.v1.everything.yml
+++ b/core/src/test/resources/nelson/manifest.v1.everything.yml
@@ -118,7 +118,6 @@ plans:
     retries: 2
     instances:
       desired: 1
-    ephemeral_disk: 200
     environment:
       - FOO=foo-1
       - QUX=qux-1

--- a/core/src/test/scala/AlertSpec.scala
+++ b/core/src/test/scala/AlertSpec.scala
@@ -47,7 +47,7 @@ class AlertSpec extends FlatSpec
 
   val nsRef = "qa"
   val alertKey = alertingKey(stackName)
-  val unit = UnitDef("http", "", Map.empty, Set.empty, alerting, Magnetar, None, None, Set.empty)
+  val unit = UnitDef("http", "", Map.empty, Set.empty, alerting, None, None, Set.empty)
 
   "alertingKey" should "be v2/:stackName" in {
     alertKey should equal ("nelson/alerting/v2/howdy-http--0-2-3--abcd1234")

--- a/core/src/test/scala/Fixtures.scala
+++ b/core/src/test/scala/Fixtures.scala
@@ -181,7 +181,6 @@ object Fixtures {
       ports = Some(c),
       dependencies = Map.empty,
       resources = Set.empty,
-      workflow = Magnetar,
       alerting = Manifest.Alerting.empty,
       deployable = None,
       meta = Set.empty[String]

--- a/core/src/test/scala/ManifestValidationSpec.scala
+++ b/core/src/test/scala/ManifestValidationSpec.scala
@@ -63,6 +63,16 @@ class ManifestValidationSpec extends NelsonSuite with TimeLimitedTests {
   }
 
   behavior of "manifest validator:"
+
+  it should "reject a manifest with a plan containing a missing blueprint" in {
+    val out = (for {
+      a <- Util.loadResourceAsString("/nelson/manifest.v1.blueprint-missing.yml")
+      b <- ManifestValidator.parseManifestAndValidate(a, config)
+    } yield b).unsafeRunSync()
+
+    val Invalid(x) = out
+  }
+
   it should "accept a valid nelson unit" in {
 
     Util.loadResourceAsString("/nelson/manifest.v1.minimal.yml").map{ manifest =>

--- a/core/src/test/scala/NelsonSuite.scala
+++ b/core/src/test/scala/NelsonSuite.scala
@@ -140,7 +140,7 @@ trait NelsonSuite
   lazy val sched = new (SchedulerOp ~> IO) {
     import scheduler.SchedulerOp._
     def apply[A](op: SchedulerOp[A]) = op match {
-      case Launch(i,dc,ns,unit,e,bp,hash) =>
+      case Launch(i,dc,ns,unit,e,hash) =>
         val name = Manifest.Versioned.unwrap(unit).name
         val sn = Datacenter.StackName(name, unit.version,hash)
         IO(sn.toString)

--- a/core/src/test/scala/ReleaseDBSpec.scala
+++ b/core/src/test/scala/ReleaseDBSpec.scala
@@ -43,7 +43,7 @@ class ReleaseDBSpec extends NelsonSuite with BeforeAndAfterEach {
   }
 
   it should "find release even if there's no deployment for unit / version" in {
-    val unit = Manifest.UnitDef("foo", "", Map.empty, Set.empty, Manifest.Alerting.empty, Magnetar,
+    val unit = Manifest.UnitDef("foo", "", Map.empty, Set.empty, Manifest.Alerting.empty,
               None, Some(Manifest.Deployable("foo", uv , Manifest.Deployable.Container(""))), Set.empty[String])
     StoreOp.addUnit(Manifest.Versioned(unit), 9999L).foldMap(config.storage).unsafeRunSync()
     val release = StoreOp.findReleasedByUnitNameAndVersion("foo", uv).foldMap(config.storage)

--- a/core/src/test/scala/RoutingFixtures.scala
+++ b/core/src/test/scala/RoutingFixtures.scala
@@ -228,7 +228,6 @@ trait RoutingFixtures {
                           Map("inventory" -> FeatureVersion(1,2)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"),Nil)),
                           Some(Deployable("ab", Version(2,2,2), Container(""))),
                           Set.empty[String]
@@ -245,7 +244,6 @@ trait RoutingFixtures {
                           Map("inventory" -> FeatureVersion(1,2)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("ab", Version(2,2,1), Container(""))),
                           Set.empty[String]
@@ -262,7 +260,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("foo", Version(1,10,100), Container(""))),
                           Set.empty[String]
@@ -279,7 +276,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("foo", Version(2,0,0), Container(""))),
                           Set.empty[String]
@@ -296,7 +292,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("search", Version(2,2,2), Container(""))),
                           Set.empty[String]
@@ -313,7 +308,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("inventory", Version(1,2,2), Container(""))),
                           Set.empty[String]
@@ -330,7 +324,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("inventory", Version(1,2,3), Container(""))),
                           Set.empty[String]
@@ -350,7 +343,6 @@ trait RoutingFixtures {
                                "search" -> FeatureVersion(2,2)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("conductor", Version(1,1,1), Container(""))),
                           Set.empty[String]
@@ -369,7 +361,6 @@ trait RoutingFixtures {
                               "search" -> FeatureVersion(2,2)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           None,
                           Set.empty[String]
@@ -386,7 +377,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           None,
                           Some(Deployable("job", Version(3,0,0), Container(""))),
                           Set.empty[String]
@@ -403,7 +393,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           None,
                           Some(Deployable("job", Version(3,1,0), Container(""))),
                           Set.empty[String]
@@ -420,7 +409,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           None,
                           Some(Deployable("job", Version(3,1,1), Container(""))),
                           Set.empty[String]
@@ -437,7 +425,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           None,
                           Some(Deployable("job", Version(4,1,0), Container(""))),
                           Set.empty[String]
@@ -454,7 +441,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           None,
                           Some(Deployable("crawler", Version(5,1,0), Container(""))),
                           Set.empty[String]
@@ -471,7 +457,6 @@ trait RoutingFixtures {
                           Map.empty,
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("search", Version(1,1,0), Container(""))),
                           Set.empty[String]
@@ -488,7 +473,6 @@ trait RoutingFixtures {
                           Map("search" -> FeatureVersion(1,1)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           None,
                           Set.empty[String]
@@ -505,7 +489,6 @@ trait RoutingFixtures {
                           Map("service-b" -> FeatureVersion(6,1)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("service-a", Version(6,0,0), Container(""))),
                           Set.empty[String]
@@ -522,7 +505,6 @@ trait RoutingFixtures {
                           Map("service-c" -> FeatureVersion(6,2)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("service-b", Version(6,1,0), Container(""))),
                           Set.empty[String]
@@ -539,7 +521,6 @@ trait RoutingFixtures {
                           Map("foo" -> FeatureVersion(1,10)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("service-c", Version(6,2,0), Container(""))),
                           Set.empty[String]
@@ -556,7 +537,6 @@ trait RoutingFixtures {
                           Map("foo" -> FeatureVersion(1,10)),
                           Set.empty,
                           Alerting.empty,
-                          Magnetar,
                           Some(Ports(Port("default", 1, "http"), Nil)),
                           Some(Deployable("service-c", Version(6,2,1), Container(""))),
                           Set.empty[String]

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -21,8 +21,8 @@ import java.nio.file.Paths
 
 import org.scalatest.{FlatSpec,Matchers}
 import scala.concurrent.duration._
-import cats.instances.either._
-import cats.syntax.foldable._
+// import cats.instances.either._
+// import cats.syntax.foldable._
 
 class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
   import Manifest._
@@ -129,7 +129,8 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
           bindings = List(
             EnvironmentVariable("FOO","foo-prod"),
             EnvironmentVariable("QUX","qux-prod")
-          )
+          ),
+          workflow = Some(Pulsar)
         )
       ),
       Plan(
@@ -160,14 +161,6 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
     )
   )
 
-                    //UnitRef("foobar", env.copy(
-                    //    bindings = List(
-                    //      EnvironmentVariable("FOO","abr"),
-                    //      EnvironmentVariable("QUX","sddf")),
-                    //    alertOptOuts = List(
-                    //      AlertOptOut("api_high_request_latency")))),
-                   // UnitRef("crawler", env))) ::
-
   def base64Encode(s: String): String =
     new String(java.util.Base64.getEncoder.encode(s.getBytes), "UTF-8")
 
@@ -177,115 +170,115 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
     loadManifest("/nelson/manifest.v1.everything.yml") should equal (Right(m1))
   }
 
-  it should "load very minimal manifests" in {
-    loadManifest("/nelson/dependencies.foo_1.0.1.yml").isRight should equal (true)
-    loadManifest("/nelson/dependencies.bar_2.0.0.yml").isRight should equal (true)
-    loadManifest("/nelson/dependencies.bar_2.1.1.yml").isRight should equal (true)
-    loadManifest("/nelson/dependencies.baz_3.3.1.yml").isRight should equal (true)
-  }
+  // it should "load very minimal manifests" in {
+  //   loadManifest("/nelson/dependencies.foo_1.0.1.yml").isRight should equal (true)
+  //   loadManifest("/nelson/dependencies.bar_2.0.0.yml").isRight should equal (true)
+  //   loadManifest("/nelson/dependencies.bar_2.1.1.yml").isRight should equal (true)
+  //   loadManifest("/nelson/dependencies.baz_3.3.1.yml").isRight should equal (true)
+  // }
 
-  it should "parse an minimal manifest file" in {
-    val a = loadManifest("/nelson/manifest.v1.minimal.yml")
-    a.isRight should equal (true)
-  }
+  // it should "parse an minimal manifest file" in {
+  //   val a = loadManifest("/nelson/manifest.v1.minimal.yml")
+  //   a.isRight should equal (true)
+  // }
 
-  it should "allow specifying a limit without a request" in {
-    val mf = loadManifest("/nelson/manifest.v1.limit-without-request.yml")
-    mf.isRight should equal (true)
-  }
+  // it should "allow specifying a limit without a request" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.limit-without-request.yml")
+  //   mf.isRight should equal (true)
+  // }
 
-  it should "reject manifests that specify a request without a limit" in {
-    val mf = loadManifest("/nelson/manifest.v1.request-without-limit.yml")
-    hasError(mf, "Cannot specify CPU request without CPU limit.")
-  }
+  // it should "reject manifests that specify a request without a limit" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.request-without-limit.yml")
+  //   hasError(mf, "Cannot specify CPU request without CPU limit.")
+  // }
 
-  it should "reject manifests with request > limit" in {
-    val mf = loadManifest("/nelson/manifest.v1.request-gt-limit.yml")
-    hasError(mf, "Invalid memory request, request must be <= 512.0 but is 1024.0")
-  }
+  // it should "reject manifests with request > limit" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.request-gt-limit.yml")
+  //   hasError(mf, "Invalid memory request, request must be <= 512.0 but is 1024.0")
+  // }
 
-  def hasError[A](mf: Either[Throwable, Manifest], slice: String) = {
-    mf.swap.exists { err =>
-      val msg = err.getMessage
-      msg.containsSlice(slice)
-    } should equal (true)
-  }
+  // def hasError[A](mf: Either[Throwable, Manifest], slice: String) = {
+  //   mf.swap.exists { err =>
+  //     val msg = err.getMessage
+  //     msg.containsSlice(slice)
+  //   } should equal (true)
+  // }
 
-  it should "provide errors for duplicate alert names in the same unit" in {
-    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-    hasError(mf, "'duplicate_alert_in_same_unit' alert name is not unique within this manifest.")
-  }
+  // it should "provide errors for duplicate alert names in the same unit" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+  //   hasError(mf, "'duplicate_alert_in_same_unit' alert name is not unique within this manifest.")
+  // }
 
-  it should "provide errors for duplicate rule names in the same unit" in {
-    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-    hasError(mf, "'duplicate_rule_in_same_unit' rule name is not unique within this manifest.")
-  }
+  // it should "provide errors for duplicate rule names in the same unit" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+  //   hasError(mf, "'duplicate_rule_in_same_unit' rule name is not unique within this manifest.")
+  // }
 
-  it should "provide errors for duplicate alert names after normalization" in {
-    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-    hasError(mf, "'duplicate_alert_after_normalization' alert name is not unique within this manifest.")
-  }
+  // it should "provide errors for duplicate alert names after normalization" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+  //   hasError(mf, "'duplicate_alert_after_normalization' alert name is not unique within this manifest.")
+  // }
 
-  it should "provide errors for duplicate rule names after normalization" in {
-    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-    hasError(mf, "'duplicate_rule_after_normalization' rule name is not unique within this manifest.")
-  }
+  // it should "provide errors for duplicate rule names after normalization" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+  //   hasError(mf, "'duplicate_rule_after_normalization' rule name is not unique within this manifest.")
+  // }
 
-  it should "provide errors for unknown unit references" in {
-    val mf = loadManifest("/nelson/manifest.v1.unknownref.yml")
-    hasError(mf, "'unknown1' isn't a valid unit reference, because it was not declared as a unit")
-    hasError(mf, "'unknown2' isn't a valid unit reference, because it was not declared as a unit")
-  }
+  // it should "provide errors for unknown unit references" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.unknownref.yml")
+  //   hasError(mf, "'unknown1' isn't a valid unit reference, because it was not declared as a unit")
+  //   hasError(mf, "'unknown2' isn't a valid unit reference, because it was not declared as a unit")
+  // }
 
-  it should "provide errors for invalid opt-outs" in {
-    val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
-    hasError(mf, "'this_is_illegal_yo' isn't a valid alert opt-out, because it was not declared in unit 'howdy'.")
-  }
+  // it should "provide errors for invalid opt-outs" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
+  //   hasError(mf, "'this_is_illegal_yo' isn't a valid alert opt-out, because it was not declared in unit 'howdy'.")
+  // }
 
-  it should "provide errors for opt-outs declared by other units" in {
-    val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
-    hasError(mf, "'api_high_request_latency' isn't a valid alert opt-out, because it was not declared in unit 'doody'.")
-  }
+  // it should "provide errors for opt-outs declared by other units" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
+  //   hasError(mf, "'api_high_request_latency' isn't a valid alert opt-out, because it was not declared in unit 'doody'.")
+  // }
 
-  it should "provide errors for invalid expiration policy for services" in {
-    val mf = loadManifest("/nelson/manifest.v1.invalid-service-expiration-policy.yml")
-    hasError(mf, "parse failed! bogus isn't a valid expiration policy.")
-  }
+  // it should "provide errors for invalid expiration policy for services" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.invalid-service-expiration-policy.yml")
+  //   hasError(mf, "parse failed! bogus isn't a valid expiration policy.")
+  // }
 
-  it should "provide errors for invalid email" in {
-    val mf = loadManifest("/nelson/manifest.v1.invalid-email.yml")
-    hasError(mf, "parse failed! randal.mcmurphy isn't a valid email")
-  }
+  // it should "provide errors for invalid email" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.invalid-email.yml")
+  //   hasError(mf, "parse failed! randal.mcmurphy isn't a valid email")
+  // }
 
-  it should "parse a manifest without any plans" in {
-    loadManifest("/nelson/manifest.v1.no-plans.yml").isRight should equal (true)
-  }
+  // it should "parse a manifest without any plans" in {
+  //   loadManifest("/nelson/manifest.v1.no-plans.yml").isRight should equal (true)
+  // }
 
-  it should "provide errors for invalid uri in resource definition" in {
-    val mf = loadManifest("/nelson/manifest.v1.invalid-uri.yml")
-    hasError(mf, "parse failed! s3:^^ is an invalid URI")
-  }
+  // it should "provide errors for invalid uri in resource definition" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.invalid-uri.yml")
+  //   hasError(mf, "parse failed! s3:^^ is an invalid URI")
+  // }
 
-  it should "provide errors for invalid CPU" in {
-    loadManifest("/nelson/manifest.v1.invalid-cpu.yml").isLeft should equal (true)
-  }
+  // it should "provide errors for invalid CPU" in {
+  //   loadManifest("/nelson/manifest.v1.invalid-cpu.yml").isLeft should equal (true)
+  // }
 
-  it should "provide errors for invalid memory" in {
-    loadManifest("/nelson/manifest.v1.invalid-memory.yml").isLeft should equal (true)
-  }
+  // it should "provide errors for invalid memory" in {
+  //   loadManifest("/nelson/manifest.v1.invalid-memory.yml").isLeft should equal (true)
+  // }
 
-  it should "provide errors for invalid instances" in {
-    loadManifest("/nelson/manifest.v1.invalid-instances.yml").isLeft should equal (true)
-  }
+  // it should "provide errors for invalid instances" in {
+  //   loadManifest("/nelson/manifest.v1.invalid-instances.yml").isLeft should equal (true)
+  // }
 
-  it should "provide errors for empty resources stanza" in {
-    val mf = loadManifest("/nelson/manifest.v1.empty-resources-stanza.yml")
-    hasError(mf, "parse failed! the field 'unit.resources' can not be empty")
-  }
+  // it should "provide errors for empty resources stanza" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.empty-resources-stanza.yml")
+  //   hasError(mf, "parse failed! the field 'unit.resources' can not be empty")
+  // }
 
-  it should "provide errors for invalid meta" in {
-    val mf = loadManifest("/nelson/manifest.v1.invalid-meta.yml")
-    hasError(mf, "parse failed! field unit.meta is not a valid alphanumeric hyphen string: a.b.c\nmeta (toooooooooooo-looooooong) must less that or equal to 14 characters")
-  }
+  // it should "provide errors for invalid meta" in {
+  //   val mf = loadManifest("/nelson/manifest.v1.invalid-meta.yml")
+  //   hasError(mf, "parse failed! field unit.meta is not a valid alphanumeric hyphen string: a.b.c\nmeta (toooooooooooo-looooooong) must less that or equal to 14 characters")
+  // }
 
 }

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -40,10 +40,8 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
               ports = Some(Ports(Port("default", 8080, "http"), Port("monitoring", 7390, "tcp") :: Nil)),
               dependencies = Map("inventory" -> FeatureVersion(1,4), "cassandra" -> FeatureVersion(1,0)),
               resources = Set(Manifest.Resource("s3", Some("description of s3"))),
-              workflow = Magnetar,
               deployable = None,
               meta = Set("foo","bar"),
-              policy = Some(RetainActive),
               alerting = Alerting(
                 PrometheusConfig(
                   alerts = List(
@@ -61,11 +59,9 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
               description = "crawler description",
               dependencies = Map("db.example" -> FeatureVersion(1,0)),
               resources = Set.empty,
-              workflow = Magnetar,
               ports = None,
               deployable = None,
               meta = Set.empty[String],
-              schedule = Some(Schedule(Once)),
               alerting = Alerting(
                 PrometheusConfig(
                   alerts = List(
@@ -85,7 +81,8 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
           alertOptOuts = List(AlertOptOut("api_high_request_latency")),
           policy = Some(RetainLatestTwoMajor),
           healthChecks = List(HealthCheck("http-status","default","https",Some("v1/status"), 10.seconds, 2.seconds)),
-          volumes = List(Volume("an-empty-dir", Paths.get("/foo/bar"), 500))
+          volumes = List(Volume("an-empty-dir", Paths.get("/foo/bar"), 500)),
+          workflow = Magnetar
         )
       ),
       Plan(
@@ -101,7 +98,8 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
             EnvironmentVariable("FOO","foo-1"),
             EnvironmentVariable("QUX","qux-1")
           ),
-          ephemeralDisk = Some(200)
+          ephemeralDisk = Some(200),
+          workflow = Magnetar
         )
       ),
       Plan(
@@ -131,14 +129,15 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
             EnvironmentVariable("FOO","foo-prod"),
             EnvironmentVariable("QUX","qux-prod")
           ),
-          workflow = Some(Pulsar),
+          workflow = Pulsar,
           blueprint = Some(Left(("qux", Blueprint.Revision.HEAD)))
         )
       ),
       Plan(
         name = "lb-plan",
         environment = Environment(
-          desiredInstances = Some(4)
+          desiredInstances = Some(4),
+          workflow = Magnetar
         )
       )
     ),

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -98,7 +98,6 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
             EnvironmentVariable("FOO","foo-1"),
             EnvironmentVariable("QUX","qux-1")
           ),
-          ephemeralDisk = Some(200),
           workflow = Magnetar
         )
       ),

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -286,7 +286,7 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
   it should "correctly parse a plan containing a blueprint reference" in {
     // note that at this point, the blueprint may not exist; the parser only
     // cares for syntax / form correctness. see manifest validator for validation.
-    val mf = loadManifest("/nelson/manifest.v1.blueprint-missing.yml").isRight should equal (true)
+    loadManifest("/nelson/manifest.v1.blueprint-missing.yml").isRight should equal (true)
   }
 
 }

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -283,4 +283,10 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
     hasError(mf, "parse failed! field unit.meta is not a valid alphanumeric hyphen string: a.b.c\nmeta (toooooooooooo-looooooong) must less that or equal to 14 characters")
   }
 
+  it should "correctly parse a plan containing a blueprint reference" in {
+    // note that at this point, the blueprint may not exist; the parser only
+    // cares for syntax / form correctness. see manifest validator for validation.
+    val mf = loadManifest("/nelson/manifest.v1.blueprint-missing.yml").isRight should equal (true)
+  }
+
 }

--- a/core/src/test/scala/yaml/ManifestYamlSpec.scala
+++ b/core/src/test/scala/yaml/ManifestYamlSpec.scala
@@ -21,14 +21,15 @@ import java.nio.file.Paths
 
 import org.scalatest.{FlatSpec,Matchers}
 import scala.concurrent.duration._
-// import cats.instances.either._
-// import cats.syntax.foldable._
+import cats.instances.either._
+import cats.syntax.foldable._
 
 class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
   import Manifest._
   import Schedule._
   import cleanup._
   import notifications._
+  import blueprint._
 
   val env = Environment(cpu = ResourceSpec.bounded(0.23, 0.23).get, memory = ResourceSpec.bounded(2048, 2048).get, desiredInstances = Some(2))
 
@@ -130,7 +131,8 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
             EnvironmentVariable("FOO","foo-prod"),
             EnvironmentVariable("QUX","qux-prod")
           ),
-          workflow = Some(Pulsar)
+          workflow = Some(Pulsar),
+          blueprint = Some(Left(("qux", Blueprint.Revision.HEAD)))
         )
       ),
       Plan(
@@ -170,115 +172,115 @@ class ManifestYamlSpec extends FlatSpec with Matchers with SnakeCharmer {
     loadManifest("/nelson/manifest.v1.everything.yml") should equal (Right(m1))
   }
 
-  // it should "load very minimal manifests" in {
-  //   loadManifest("/nelson/dependencies.foo_1.0.1.yml").isRight should equal (true)
-  //   loadManifest("/nelson/dependencies.bar_2.0.0.yml").isRight should equal (true)
-  //   loadManifest("/nelson/dependencies.bar_2.1.1.yml").isRight should equal (true)
-  //   loadManifest("/nelson/dependencies.baz_3.3.1.yml").isRight should equal (true)
-  // }
+  it should "load very minimal manifests" in {
+    loadManifest("/nelson/dependencies.foo_1.0.1.yml").isRight should equal (true)
+    loadManifest("/nelson/dependencies.bar_2.0.0.yml").isRight should equal (true)
+    loadManifest("/nelson/dependencies.bar_2.1.1.yml").isRight should equal (true)
+    loadManifest("/nelson/dependencies.baz_3.3.1.yml").isRight should equal (true)
+  }
 
-  // it should "parse an minimal manifest file" in {
-  //   val a = loadManifest("/nelson/manifest.v1.minimal.yml")
-  //   a.isRight should equal (true)
-  // }
+  it should "parse an minimal manifest file" in {
+    val a = loadManifest("/nelson/manifest.v1.minimal.yml")
+    a.isRight should equal (true)
+  }
 
-  // it should "allow specifying a limit without a request" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.limit-without-request.yml")
-  //   mf.isRight should equal (true)
-  // }
+  it should "allow specifying a limit without a request" in {
+    val mf = loadManifest("/nelson/manifest.v1.limit-without-request.yml")
+    mf.isRight should equal (true)
+  }
 
-  // it should "reject manifests that specify a request without a limit" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.request-without-limit.yml")
-  //   hasError(mf, "Cannot specify CPU request without CPU limit.")
-  // }
+  it should "reject manifests that specify a request without a limit" in {
+    val mf = loadManifest("/nelson/manifest.v1.request-without-limit.yml")
+    hasError(mf, "Cannot specify CPU request without CPU limit.")
+  }
 
-  // it should "reject manifests with request > limit" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.request-gt-limit.yml")
-  //   hasError(mf, "Invalid memory request, request must be <= 512.0 but is 1024.0")
-  // }
+  it should "reject manifests with request > limit" in {
+    val mf = loadManifest("/nelson/manifest.v1.request-gt-limit.yml")
+    hasError(mf, "Invalid memory request, request must be <= 512.0 but is 1024.0")
+  }
 
-  // def hasError[A](mf: Either[Throwable, Manifest], slice: String) = {
-  //   mf.swap.exists { err =>
-  //     val msg = err.getMessage
-  //     msg.containsSlice(slice)
-  //   } should equal (true)
-  // }
+  def hasError[A](mf: Either[Throwable, Manifest], slice: String) = {
+    mf.swap.exists { err =>
+      val msg = err.getMessage
+      msg.containsSlice(slice)
+    } should equal (true)
+  }
 
-  // it should "provide errors for duplicate alert names in the same unit" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-  //   hasError(mf, "'duplicate_alert_in_same_unit' alert name is not unique within this manifest.")
-  // }
+  it should "provide errors for duplicate alert names in the same unit" in {
+    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+    hasError(mf, "'duplicate_alert_in_same_unit' alert name is not unique within this manifest.")
+  }
 
-  // it should "provide errors for duplicate rule names in the same unit" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-  //   hasError(mf, "'duplicate_rule_in_same_unit' rule name is not unique within this manifest.")
-  // }
+  it should "provide errors for duplicate rule names in the same unit" in {
+    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+    hasError(mf, "'duplicate_rule_in_same_unit' rule name is not unique within this manifest.")
+  }
 
-  // it should "provide errors for duplicate alert names after normalization" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-  //   hasError(mf, "'duplicate_alert_after_normalization' alert name is not unique within this manifest.")
-  // }
+  it should "provide errors for duplicate alert names after normalization" in {
+    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+    hasError(mf, "'duplicate_alert_after_normalization' alert name is not unique within this manifest.")
+  }
 
-  // it should "provide errors for duplicate rule names after normalization" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
-  //   hasError(mf, "'duplicate_rule_after_normalization' rule name is not unique within this manifest.")
-  // }
+  it should "provide errors for duplicate rule names after normalization" in {
+    val mf = loadManifest("/nelson/manifest.v1.duplicate-alerts.yml")
+    hasError(mf, "'duplicate_rule_after_normalization' rule name is not unique within this manifest.")
+  }
 
-  // it should "provide errors for unknown unit references" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.unknownref.yml")
-  //   hasError(mf, "'unknown1' isn't a valid unit reference, because it was not declared as a unit")
-  //   hasError(mf, "'unknown2' isn't a valid unit reference, because it was not declared as a unit")
-  // }
+  it should "provide errors for unknown unit references" in {
+    val mf = loadManifest("/nelson/manifest.v1.unknownref.yml")
+    hasError(mf, "'unknown1' isn't a valid unit reference, because it was not declared as a unit")
+    hasError(mf, "'unknown2' isn't a valid unit reference, because it was not declared as a unit")
+  }
 
-  // it should "provide errors for invalid opt-outs" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
-  //   hasError(mf, "'this_is_illegal_yo' isn't a valid alert opt-out, because it was not declared in unit 'howdy'.")
-  // }
+  it should "provide errors for invalid opt-outs" in {
+    val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
+    hasError(mf, "'this_is_illegal_yo' isn't a valid alert opt-out, because it was not declared in unit 'howdy'.")
+  }
 
-  // it should "provide errors for opt-outs declared by other units" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
-  //   hasError(mf, "'api_high_request_latency' isn't a valid alert opt-out, because it was not declared in unit 'doody'.")
-  // }
+  it should "provide errors for opt-outs declared by other units" in {
+    val mf = loadManifest("/nelson/manifest.v1.invalid-alert-opt-out.yml")
+    hasError(mf, "'api_high_request_latency' isn't a valid alert opt-out, because it was not declared in unit 'doody'.")
+  }
 
-  // it should "provide errors for invalid expiration policy for services" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.invalid-service-expiration-policy.yml")
-  //   hasError(mf, "parse failed! bogus isn't a valid expiration policy.")
-  // }
+  it should "provide errors for invalid expiration policy for services" in {
+    val mf = loadManifest("/nelson/manifest.v1.invalid-service-expiration-policy.yml")
+    hasError(mf, "parse failed! bogus isn't a valid expiration policy.")
+  }
 
-  // it should "provide errors for invalid email" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.invalid-email.yml")
-  //   hasError(mf, "parse failed! randal.mcmurphy isn't a valid email")
-  // }
+  it should "provide errors for invalid email" in {
+    val mf = loadManifest("/nelson/manifest.v1.invalid-email.yml")
+    hasError(mf, "parse failed! randal.mcmurphy isn't a valid email")
+  }
 
-  // it should "parse a manifest without any plans" in {
-  //   loadManifest("/nelson/manifest.v1.no-plans.yml").isRight should equal (true)
-  // }
+  it should "parse a manifest without any plans" in {
+    loadManifest("/nelson/manifest.v1.no-plans.yml").isRight should equal (true)
+  }
 
-  // it should "provide errors for invalid uri in resource definition" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.invalid-uri.yml")
-  //   hasError(mf, "parse failed! s3:^^ is an invalid URI")
-  // }
+  it should "provide errors for invalid uri in resource definition" in {
+    val mf = loadManifest("/nelson/manifest.v1.invalid-uri.yml")
+    hasError(mf, "parse failed! s3:^^ is an invalid URI")
+  }
 
-  // it should "provide errors for invalid CPU" in {
-  //   loadManifest("/nelson/manifest.v1.invalid-cpu.yml").isLeft should equal (true)
-  // }
+  it should "provide errors for invalid CPU" in {
+    loadManifest("/nelson/manifest.v1.invalid-cpu.yml").isLeft should equal (true)
+  }
 
-  // it should "provide errors for invalid memory" in {
-  //   loadManifest("/nelson/manifest.v1.invalid-memory.yml").isLeft should equal (true)
-  // }
+  it should "provide errors for invalid memory" in {
+    loadManifest("/nelson/manifest.v1.invalid-memory.yml").isLeft should equal (true)
+  }
 
-  // it should "provide errors for invalid instances" in {
-  //   loadManifest("/nelson/manifest.v1.invalid-instances.yml").isLeft should equal (true)
-  // }
+  it should "provide errors for invalid instances" in {
+    loadManifest("/nelson/manifest.v1.invalid-instances.yml").isLeft should equal (true)
+  }
 
-  // it should "provide errors for empty resources stanza" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.empty-resources-stanza.yml")
-  //   hasError(mf, "parse failed! the field 'unit.resources' can not be empty")
-  // }
+  it should "provide errors for empty resources stanza" in {
+    val mf = loadManifest("/nelson/manifest.v1.empty-resources-stanza.yml")
+    hasError(mf, "parse failed! the field 'unit.resources' can not be empty")
+  }
 
-  // it should "provide errors for invalid meta" in {
-  //   val mf = loadManifest("/nelson/manifest.v1.invalid-meta.yml")
-  //   hasError(mf, "parse failed! field unit.meta is not a valid alphanumeric hyphen string: a.b.c\nmeta (toooooooooooo-looooooong) must less that or equal to 14 characters")
-  // }
+  it should "provide errors for invalid meta" in {
+    val mf = loadManifest("/nelson/manifest.v1.invalid-meta.yml")
+    hasError(mf, "parse failed! field unit.meta is not a valid alphanumeric hyphen string: a.b.c\nmeta (toooooooooooo-looooooong) must less that or equal to 14 characters")
+  }
 
 }


### PR DESCRIPTION
resolves #86 

This PR adds support for validating manifests with blueprints. Note that the implementation is done in two steps, and is a breaking change for manifests working with Nelson 0.11.x or older (essentially all manifests).

1. The blueprint reference (e.g. `something@HEAD`) is first checked for structural validity in the parser; in this case three forms for blueprint reference are allow, as denoted by the blueprint reference: https://github.com/getnelson/nelson/blob/master/core/src/main/scala/blueprint/Blueprint.scala#L39

2. Assuming the manifest is parsable, then the `ManifestValidator` will then be engaged to check the blueprint reference is actually valid and present in the database. In the event the blueprint is not found, the process will short-circuit with an error. In the event the manifest validator finds no errors, it will update the supplied manifest with the plans containing the hydrated `Blueprint`'s 