### PR TITLE
dynamically include the nelson-cli release data 

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -47,7 +47,18 @@ hugoGenerateData := {
   dest
 }
 
-makeSite := makeSite.dependsOn(hugoGenerateData).value
+val latestCLIReleaseData = taskKey[File]("hugo-cli-release-data")
+
+latestCLIReleaseData := {
+  val dest = (sourceDirectory in Hugo).value / "data" / "release.json"
+  val contents = scala.io.Source.fromInputStream(
+    new java.net.URL("https://api.github.com/repos/getnelson/nelson-cli/releases/latest"
+      ).openConnection.getInputStream).mkString
+  IO.write(dest, contents)
+  dest
+}
+
+makeSite := makeSite.dependsOn(hugoGenerateData, latestCLIReleaseData).value
 
 import com.typesafe.sbt.SbtGit.GitKeys.{gitBranch, gitRemoteRepo}
 

--- a/docs/src/hugo/content/downloads.md
+++ b/docs/src/hugo/content/downloads.md
@@ -9,7 +9,7 @@ preamble: >
 
 The client is shipped as a static binary that comes pre-compiled for a variety of operating systems. The tables below enumerate the direct-download sites for the latest version (presently v{{< version >}}).
 
-{{< downloads_client >}}{{< version >}}{{< /downloads_client >}}
+{{< downloads_client >}}{{< cli_version >}}{{< /downloads_client >}}
 
 ## Server
 

--- a/docs/src/hugo/layouts/shortcodes/cli_version.html
+++ b/docs/src/hugo/layouts/shortcodes/cli_version.html
@@ -1,0 +1,1 @@
+{{ with .Site.Data.releases }}{{ .tag_name }}{{ else }}{{ "latest" }}{{ end }}


### PR DESCRIPTION
so that the docs site knows what the latest version is without having to hardcode it