### PR TITLE
Migrate to v2.0 of the end user template linting containers

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -183,10 +183,18 @@ nelson {
   template {
     temp-dir = "/tmp"
     memory-mb = 8
+    # specify the CPU CFS scheduler period, which is used alongside
+    # cpu-quota. defaults to 100 micro-seconds.
     cpu-period = 100000
+    # impose a CPU CFS quota on the container. The number of microseconds
+    # per cpu-period that the container is limited to before throttled.
+    # as such acting as the effective ceiling for the execution.
     cpu-quota = 50000
+    # how long to give the container before it is actively killed.
     timeout = 10 seconds
-    consul-template-image = "verizon/nelson-template-linter:1.0.1"
+    # what container shall we use? for information about the linting
+    # engine protocol please see here: https://github.com/getnelson/containers#linters
+    template-engine-image = "getnelson/linter-consul-template:2.0.12"
   }
 
   workflow-logger {

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -190,7 +190,7 @@ final case class TemplateConfig(
   cpuPeriod: Int,
   cpuQuota: Int,
   timeout: FiniteDuration,
-  consulTemplateImage: String,
+  templateEngineImage: String,
   vaultAddress: Option[String]
 )
 
@@ -504,7 +504,7 @@ object Config {
       cpuPeriod = tCfg.require[Int]("cpu-period"),
       cpuQuota = tCfg.require[Int]("cpu-quota"),
       timeout = tCfg.require[FiniteDuration]("timeout"),
-      consulTemplateImage = tCfg.require[String]("consul-template-image"),
+      templateEngineImage = tCfg.require[String]("template-engine-image"),
       vaultAddress = vaultAddress
     )
   }

--- a/core/src/main/scala/Metrics.scala
+++ b/core/src/main/scala/Metrics.scala
@@ -26,25 +26,25 @@ import io.prometheus.client._
 // To avoid redefinition of Metrics, all metrics should be defined here.
 // Bonus points if you keep it alphabetical.
 class Metrics(registry: CollectorRegistry) {
-  val consulTemplateRunsDurationSeconds = (new Histogram.Builder)
+  val lintTemplateRunsDurationSeconds = (new Histogram.Builder)
     .name("consul_template_runs_duration_seconds")
     .help("Duration of consul template runs, in seconds")
     .register(registry)
 
-  val consulTemplateRunsFailuresTotal = (new Counter.Builder)
+  val lintTemplateRunsFailuresTotal = (new Counter.Builder)
     .labelNames("reason")
-    .name("consul_template_runs_failures_total")
-    .help("consul-template runs that failed to render a template")
+    .name("lint_template_runs_failures_total")
+    .help("lint-template runs that failed to render a template")
     .register(registry)
 
-  val consulTemplateContainersRunning = (new Gauge.Builder)
-    .name("consul_template_containers_running")
-    .help("number of consul-template containers currently running")
+  val lintTemplateContainersRunning = (new Gauge.Builder)
+    .name("lint_template_containers_running")
+    .help("number of lint-template containers currently running")
     .register(registry)
 
-  val consulTemplateContainerCleanupFailuresTotal = (new Counter.Builder)
-    .name("consul_template_container_cleanup_failures_total")
-    .help("consul-template containers that we could not clean up")
+  val lintTemplateContainerCleanupFailuresTotal = (new Counter.Builder)
+    .name("lint_template_container_cleanup_failures_total")
+    .help("lint-template containers that we could not clean up")
     .register(registry)
 
   val deploymentMonitorAwaitingHealth = Counter.build

--- a/core/src/test/resources/nelson/nelson-test.cfg
+++ b/core/src/test/resources/nelson/nelson-test.cfg
@@ -34,6 +34,6 @@ nelson {
   proxy-port-whitelist = [ 80, 443, 8080, 8444, 9000, 9001 ]
 
   template {
-    consul-template-image = "verizon/nelson-consul-template:1.0.1"
+    consul-template-image = "getnelson/linter-consul-template:2.0.12"
   }
 }

--- a/core/src/test/scala/TemplatesSpec.scala
+++ b/core/src/test/scala/TemplatesSpec.scala
@@ -39,9 +39,10 @@ class TemplatesSpec extends FlatSpec with NelsonSuite {
   def render(file: String, timeout: FiniteDuration = 15.seconds) =
     renderTemplate(config.pools.defaultExecutor, config.pools.schedulingPool, config.template.copy(timeout = timeout), config.dockercfg,
       templatePath(file), DummyVaultToken, ExtraEnv)
+
   behavior of "runTemplates"
 
-  ignore should "return Rendered if it can be rendered" in {
+  it should "return Rendered if it can be rendered" in {
     render("valid").unsafeRunSync() should be (Rendered)
   }
 
@@ -57,7 +58,7 @@ class TemplatesSpec extends FlatSpec with NelsonSuite {
     }
   }
 
-  ignore should "expose custom environment variables" in {
+  it should "expose custom environment variables" in {
     render("custom-token").unsafeRunSync() shouldBe (Rendered)
   }
 


### PR DESCRIPTION
resolves https://github.com/getnelson/nelson/issues/148

The container side of this was implemented here: https://github.com/getnelson/containers/pull/3 allowing arbitrary rendering engines to be used, as desired.