### PR TITLE
support EC2/ECS discovery for credentials

### DIFF
--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -702,9 +702,7 @@ object Config {
 
       val ec2Discovery = Option(new EC2ContainerCredentialsProviderWrapper())
 
-      val profile = Option(new ProfileCredentialsProvider())
-
-      (basic :: profile :: ec2Discovery :: Nil)
+      (basic :: ec2Discovery :: Nil)
         .sequence[Option, AWSCredentialsProvider]
         .map(ps => new AWSCredentialsProviderChain(ps: _*))
     }

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -18,7 +18,7 @@ package nelson
 
 import nelson.BannedClientsConfig.HttpUserAgent
 import nelson.Infrastructure.KubernetesMode
-import nelson.audit.{Auditor, AuditEvent}
+import nelson.audit.{Auditor,AuditEvent}
 import nelson.cleanup.ExpirationPolicy
 import nelson.docker.Docker
 import nelson.health.KubernetesHealthClient

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -29,8 +29,7 @@ import nelson.storage.StoreOp
 import nelson.vault._
 import nelson.vault.http4s._
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, BasicAWSCredentials, EC2ContainerCredentialsProviderWrapper}
+import com.amazonaws.auth.{AWSCredentialsProviderChain, BasicAWSCredentials, EC2ContainerCredentialsProviderWrapper}
 import com.amazonaws.internal.StaticCredentialsProvider
 
 import cats.~>

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -18,12 +18,12 @@ package nelson
 
 import nelson.BannedClientsConfig.HttpUserAgent
 import nelson.Infrastructure.KubernetesMode
-import nelson.audit.{AuditEvent, Auditor}
+import nelson.audit.{Auditor, AuditEvent}
 import nelson.cleanup.ExpirationPolicy
 import nelson.docker.Docker
 import nelson.health.KubernetesHealthClient
-import nelson.logging.{LoggingOp, WorkflowLogger}
-import nelson.notifications.{EmailOp, EmailServer, SlackHttp, SlackOp}
+import nelson.logging.{WorkflowLogger, LoggingOp}
+import nelson.notifications.{SlackHttp,SlackOp,EmailOp,EmailServer}
 import nelson.scheduler.{KubernetesShell, SchedulerOp}
 import nelson.storage.StoreOp
 import nelson.vault._

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -695,8 +695,6 @@ object Config {
     val zones = readAvailabilityZones(kfg.subconfig("availability-zones"))
 
     def lookupProviderChain(kfg: KConfig): Option[AWSCredentialsProviderChain] = {
-      import cats.implicits._
-
       val basic = for {
         ak <- kfg.lookup[String]("access-key-id")
         sk <- kfg.lookup[String]("secret-access-key")

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -28,17 +28,21 @@ import nelson.scheduler.{KubernetesShell, SchedulerOp}
 import nelson.storage.StoreOp
 import nelson.vault._
 import nelson.vault.http4s._
-import cats.~>
-import cats.effect.{Effect, IO}
-import cats.implicits._
-import java.nio.file.{Path, Paths}
-import java.util.concurrent.{ExecutorService, Executors, ScheduledExecutorService, ThreadFactory}
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, BasicAWSCredentials, EC2ContainerCredentialsProviderWrapper}
 import com.amazonaws.internal.StaticCredentialsProvider
+
+import cats.~>
+import cats.effect.{Effect, IO}
+import cats.implicits._
+
+import java.nio.file.{Path, Paths}
+import java.util.concurrent.{ExecutorService, Executors, ScheduledExecutorService, ThreadFactory}
 import javax.net.ssl.SSLContext
+
 import journal.Logger
+
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.client.blaze._

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -22,7 +22,7 @@ import nelson.audit.{Auditor, AuditEvent}
 import nelson.cleanup.ExpirationPolicy
 import nelson.docker.Docker
 import nelson.health.KubernetesHealthClient
-import nelson.logging.{WorkflowLogger, LoggingOp}
+import nelson.logging.{WorkflowLogger,LoggingOp}
 import nelson.notifications.{SlackHttp,SlackOp,EmailOp,EmailServer}
 import nelson.scheduler.{KubernetesShell, SchedulerOp}
 import nelson.storage.StoreOp

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -25,7 +25,7 @@ import nelson.scheduler.SchedulerOp
 import nelson.storage.StoreOp
 import nelson.vault.Vault
 
-import cats.{~>,Order}
+import cats.{~>, Order}
 import cats.data.ValidatedNel
 import cats.effect.IO
 import cats.implicits._

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -24,17 +24,21 @@ import nelson.logging.LoggingOp
 import nelson.scheduler.SchedulerOp
 import nelson.storage.StoreOp
 import nelson.vault.Vault
-import cats.{Order, ~>}
+
+import cats.{~>,Order}
 import cats.data.ValidatedNel
 import cats.effect.IO
 import cats.implicits._
+
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.Region
+
 import helm.ConsulOp
+
 import java.net.URI
 import java.time.Instant
 import java.nio.file.Path
 
-import com.amazonaws.auth.AWSCredentialsProviderChain
 import org.http4s.Uri
 
 import scala.concurrent.duration.FiniteDuration

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -24,20 +24,17 @@ import nelson.logging.LoggingOp
 import nelson.scheduler.SchedulerOp
 import nelson.storage.StoreOp
 import nelson.vault.Vault
-
-import cats.{~>, Order}
+import cats.{Order, ~>}
 import cats.data.ValidatedNel
 import cats.effect.IO
 import cats.implicits._
-
 import com.amazonaws.regions.Region
-
 import helm.ConsulOp
-
 import java.net.URI
 import java.time.Instant
 import java.nio.file.Path
 
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import org.http4s.Uri
 
 import scala.concurrent.duration.FiniteDuration
@@ -108,19 +105,15 @@ object Infrastructure {
   )
 
   final case class Aws(
-    accessKeyId: String,
-    secretAccessKey: String,
+    private val creds: AWSCredentialsProviderChain,
     region: Region,
     launchConfigurationName: String,
     elbSecurityGroupNames: Set[String],
     availabilityZones: Set[AvailabilityZone] = Set.empty,
     image: String
   ) {
-    import com.amazonaws.auth.BasicAWSCredentials
     import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
     import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
-
-    private val creds = new BasicAWSCredentials(accessKeyId, secretAccessKey)
 
     val asg = new AmazonAutoScalingClient(creds)
       .withRegion[AmazonAutoScalingClient](region)

--- a/docs/src/hugo/content/getting-started/install.md
+++ b/docs/src/hugo/content/getting-started/install.md
@@ -359,11 +359,19 @@ This command - or a command like it - can be run from any system with Docker ins
 Nelson's database is a simple <a href="http://www.h2database.com/">H2</a> file-based datastore. Nelson is intended to be running as a singleton and currently does not support clustering. Support for high-availability deployment modes are planned for a future release, but typically this is not needed as outages of Nelson have no critical affect on the datacenter runtime.
 </div>
 
-### Running on Kubernetes
+### Running in Containers
 
-Nelson can also be operated on top of Kubernetes (even if that same cluster is the one being managed by Nelson). When deploying to Kubernetes, Nelson operates like any other container applciation with the exception that it requires the use of a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to which Nelson can journal its state (database, job logs etc).
+#### Kubernetes
+
+Nelson can also be operated on top of Kubernetes (even if that same cluster is the one being managed by Nelson). When deploying to containerized environments, Nelson operates like any other container application with the exception that it requires the use of a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to which Nelson can journal its state (database, job logs etc). Depending on your infrastructure and tooling, special considerations should be taken, some of which are detailed below.
 
 As the Kubernetes configurations are rather verbose, the Nelson teams has provided a set of example configuration files [in the getnelson/kubernetes-configuration](https://github.com/getnelson/kubernetes-configuration) repository on Github.
+
+#### AWS ECS
+
+Since ECS does not support a logical volume claims, like Kubernetes and Nomad, special care must be taken to ensure Nelson can journal its state (database, job logs etc). At the time of writing, Nelson should not be deployed to a Fargate cluster due to lack of native support for persistent volumes. It may be possible for more advanced operators to construct a resilient storage solution using multiple containers and bind mounts.
+
+For beginners, the easiest deployment solution will utilize a dedicated ECS cluster and a dedicated EFS filesystem. The EFS filesystem will be [attached to the Nelson container](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_efs.html) and provides persistence guarantees across restarts in all virtualization layers. Deployment into an existing cluster is possible if the operator configures IAM to permit the ECS cluster to create the mount target, but restricts mount target access to a security group held only by Nelson.
 
 ### Installation Complete
 


### PR DESCRIPTION
Fixes #180 

Currently, the AWS infrastructure configuration demands the use of basic credentials. While these can be securely provided through a number of solutions, falling back on IAM discovery can eliminate their need entirely when users are operating on a platform which supports use of the EC2 metadata service.