### PR TITLE
[breaking] refactor how configuration is loaded for schedulers

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -238,19 +238,19 @@ nelson {
   #   texas {
   #     domain = "your.company.com"
   #     docker-registry = "registry.service.texas.your.company.com/whatever"
-
+  #
   #     infrastructure {
   #       # values can be "kubernetes" | "nomad"
   #       scheduler = "nomad"
   #       # values can be "kubernetes" | "consul" | "consul:lighthouse" | "noop"
   #       routing = "consul:lighthouse"
-
+  #
   #       kubernetes {
   #         in-cluster = false
   #         timeout    = 3 seconds
   #         kubeconfig = "/opt/application/conf/kubeconfig"
   #       }
-
+  #
   #       nomad {
   #         endpoint = "http://nomad.service.texas.your.company.com:1234/"
   #         timeout = 1 second
@@ -260,7 +260,7 @@ nelson {
   #           password = "dummypwd"
   #         }
   #       }
-
+  #
   #       consul {
   #         endpoint  = "http://consul.service.texas.your.company.com"
   #         timeout   = 1 second
@@ -268,7 +268,7 @@ nelson {
   #         username  = "XXXXXXXXX"
   #         password  = "XXXXXXXXX"
   #       }
-
+  #
   #       vault {
   #         endpoint   = "https://vault.service.texas.your.company.com:1234"
   #         auth-token = "XXXXXXXXX"
@@ -279,7 +279,7 @@ nelson {
   #         # specify a prefix that will be prepended to the datacenter name:
   #         auth-role-prefix = "aws-"
   #       }
-
+  #
   #       loadbalancer {
   #         aws {
   #            # access-key-id and secret-access-key are OPTIONAL
@@ -300,12 +300,13 @@ nelson {
   #         }
   #       }
   #     }
+  #
   #     policy {
   #       # Path under which credentials are stored for
   #       # resources.  Units will get read capability on each resource.
   #       # Supported variables: %env%, %resource%, %unit%
   #       resource-creds-path = "nelson/%env%/%resource%/creds/%unit%"
-
+  #
   #       # Path to your PKI backend. Optional. If specified, unit will get
   #       # create and update capabilities on ${pki-path}/issue
   #       # Supported variables: %env%

--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -234,83 +234,83 @@ nelson {
   ######## datacenter configuration.
   # no defaults are assumed here, as this must be provided by the implementor.
   # this section included here for documentation purposes only.
-  datacenters {
-    texas {
-      domain = "your.company.com"
-      docker-registry = "registry.service.texas.your.company.com/whatever"
+  # datacenters {
+  #   texas {
+  #     domain = "your.company.com"
+  #     docker-registry = "registry.service.texas.your.company.com/whatever"
 
-      infrastructure {
-        # values can be "kubernetes" | "nomad"
-        scheduler = "nomad"
-        # values can be "kubernetes" | "consul" | "consul:lighthouse" | "noop"
-        routing = "consul:lighthouse"
+  #     infrastructure {
+  #       # values can be "kubernetes" | "nomad"
+  #       scheduler = "nomad"
+  #       # values can be "kubernetes" | "consul" | "consul:lighthouse" | "noop"
+  #       routing = "consul:lighthouse"
 
-        kubernetes {
-          in-cluster = false
-          timeout    = 3 seconds
-          kubeconfig = "/opt/application/conf/kubeconfig"
-        }
+  #       kubernetes {
+  #         in-cluster = false
+  #         timeout    = 3 seconds
+  #         kubeconfig = "/opt/application/conf/kubeconfig"
+  #       }
 
-        nomad {
-          endpoint = "http://nomad.service.texas.your.company.com:1234/"
-          timeout = 1 second
-          docker {
-            host = "registry.service.texas.your.company.com"
-            user = "someuser"
-            password = "dummypwd"
-          }
-        }
+  #       nomad {
+  #         endpoint = "http://nomad.service.texas.your.company.com:1234/"
+  #         timeout = 1 second
+  #         docker {
+  #           host = "registry.service.texas.your.company.com"
+  #           user = "someuser"
+  #           password = "dummypwd"
+  #         }
+  #       }
 
-        consul {
-          endpoint  = "http://consul.service.texas.your.company.com"
-          timeout   = 1 second
-          acl-token = "XXXXXXXXX"
-          username  = "XXXXXXXXX"
-          password  = "XXXXXXXXX"
-        }
+  #       consul {
+  #         endpoint  = "http://consul.service.texas.your.company.com"
+  #         timeout   = 1 second
+  #         acl-token = "XXXXXXXXX"
+  #         username  = "XXXXXXXXX"
+  #         password  = "XXXXXXXXX"
+  #       }
 
-        vault {
-          endpoint   = "https://vault.service.texas.your.company.com:1234"
-          auth-token = "XXXXXXXXX"
-          timeout    = 5 seconds
-          # optional: if your backend auth provider (for kubernetes, as one example)
-          # has the same name as the datacenter, you can ignore this field. Given
-          # this is not typically the case (people have some convention) then you can
-          # specify a prefix that will be prepended to the datacenter name:
-          auth-role-prefix = "aws-"
-        }
+  #       vault {
+  #         endpoint   = "https://vault.service.texas.your.company.com:1234"
+  #         auth-token = "XXXXXXXXX"
+  #         timeout    = 5 seconds
+  #         # optional: if your backend auth provider (for kubernetes, as one example)
+  #         # has the same name as the datacenter, you can ignore this field. Given
+  #         # this is not typically the case (people have some convention) then you can
+  #         # specify a prefix that will be prepended to the datacenter name:
+  #         auth-role-prefix = "aws-"
+  #       }
 
-        loadbalancer {
-          aws {
-             # access-key-id and secret-access-key are OPTIONAL
-             # one can use the IAM instance provider
-             access-key-id = "XXXXXXXXX"
-             secret-access-key = "XXXXXXXXX"
-             region = "texas"
-             launch-configuration-name = "nelson-lb-1-LaunchConfig-XXXXXXXXXXXXXXXXXX"
-             # image is optional
-             image = "registry.service.texas.your.company.com/whatever/infra-lb:1.2.3"
-             elb-security-group-names = [ "sg-AAAAAAAA", "sg-BBBBBBB" ]
-             availability-zones {
-               texas-a {
-                 private-subnet = "subnet-AAAAAAAA"
-                 public-subnet = "subnet-BBBBBBB"
-               }
-             }
-          }
-        }
-      }
-      policy {
-        # Path under which credentials are stored for
-        # resources.  Units will get read capability on each resource.
-        # Supported variables: %env%, %resource%, %unit%
-        resource-creds-path = "nelson/%env%/%resource%/creds/%unit%"
+  #       loadbalancer {
+  #         aws {
+  #            # access-key-id and secret-access-key are OPTIONAL
+  #            # one can use the IAM instance provider
+  #            access-key-id = "XXXXXXXXX"
+  #            secret-access-key = "XXXXXXXXX"
+  #            region = "texas"
+  #            launch-configuration-name = "nelson-lb-1-LaunchConfig-XXXXXXXXXXXXXXXXXX"
+  #            # image is optional
+  #            image = "registry.service.texas.your.company.com/whatever/infra-lb:1.2.3"
+  #            elb-security-group-names = [ "sg-AAAAAAAA", "sg-BBBBBBB" ]
+  #            availability-zones {
+  #              texas-a {
+  #                private-subnet = "subnet-AAAAAAAA"
+  #                public-subnet = "subnet-BBBBBBB"
+  #              }
+  #            }
+  #         }
+  #       }
+  #     }
+  #     policy {
+  #       # Path under which credentials are stored for
+  #       # resources.  Units will get read capability on each resource.
+  #       # Supported variables: %env%, %resource%, %unit%
+  #       resource-creds-path = "nelson/%env%/%resource%/creds/%unit%"
 
-        # Path to your PKI backend. Optional. If specified, unit will get
-        # create and update capabilities on ${pki-path}/issue
-        # Supported variables: %env%
-        # pki-path = "pki"
-      }
-    }
-  }
+  #       # Path to your PKI backend. Optional. If specified, unit will get
+  #       # create and update capabilities on ${pki-path}/issue
+  #       # Supported variables: %env%
+  #       # pki-path = "pki"
+  #     }
+  #   }
+  # }
 }

--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -234,80 +234,83 @@ nelson {
   ######## datacenter configuration.
   # no defaults are assumed here, as this must be provided by the implementor.
   # this section included here for documentation purposes only.
-  # datacenters {
-  #   texas {
-  #     domain = "your.company.com"
-  #     docker-registry = "registry.service.texas.your.company.com/whatever"
-  #
-  #     infrastructure {
-  #       scheduler {
-  #         scheduler = "nomad"
-  #         kubernetes {
-  #           in-cluster = false
-  #           timeout    = 10 seconds
-  #           kubeconfig = "/opt/application/conf/kubeconfig"
-  #         }
-  #         nomad {
-  #           endpoint = "http://nomad.service.texas.your.company.com:1234/"
-  #           timeout = 1 second
-  #           docker {
-  #             host = "registry.service.texas.your.company.com"
-  #             user = "someuser"
-  #             password = "dummypwd"
-  #           }
-  #         }
-  #       }
-  #
-  #       consul {
-  #         endpoint  = "http://consul.service.texas.your.company.com"
-  #         timeout   = 1 second
-  #         acl-token = "XXXXXXXXX"
-  #         username  = "XXXXXXXXX"
-  #         password  = "XXXXXXXXX"
-  #       }
-  #
-  #       vault {
-  #         endpoint   = "https://vault.service.texas.your.company.com:1234"
-  #         auth-token = "XXXXXXXXX"
-  #         timeout    = 5 seconds
-  #         # optional: if your backend auth provider (for kubernetes, as one example)
-  #         # has the same name as the datacenter, you can ignore this field. Given
-  #         # this is not typically the case (people have some convention) then you can
-  #         # specify a prefix that will be prepended to the datacenter name:
-  #         auth-role-prefix = "aws-"
-  #       }
-  #
-  #       loadbalancer {
-  #         aws {
-  #            # access-key-id and secret-access-key are OPTIONAL
-  #            # one can use the IAM instance provider
-  #            access-key-id = "XXXXXXXXX"
-  #            secret-access-key = "XXXXXXXXX"
-  #            region = "texas"
-  #            launch-configuration-name = "nelson-lb-1-LaunchConfig-XXXXXXXXXXXXXXXXXX"
-  #            # image is optional
-  #            image = "registry.service.texas.your.company.com/whatever/infra-lb:1.2.3"
-  #            elb-security-group-names = [ "sg-AAAAAAAA", "sg-BBBBBBB" ]
-  #            availability-zones {
-  #              texas-a {
-  #                private-subnet = "subnet-AAAAAAAA"
-  #                public-subnet = "subnet-BBBBBBB"
-  #              }
-  #            }
-  #         }
-  #       }
-  #     }
-  #     policy {
-  #       # Path under which credentials are stored for
-  #       # resources.  Units will get read capability on each resource.
-  #       # Supported variables: %env%, %resource%, %unit%
-  #       resource-creds-path = "nelson/%env%/%resource%/creds/%unit%"
-  #
-  #       # Path to your PKI backend. Optional. If specified, unit will get
-  #       # create and update capabilities on ${pki-path}/issue
-  #       # Supported variables: %env%
-  #       # pki-path = "pki"
-  #     }
-  #   }
-  # }
+  datacenters {
+    texas {
+      domain = "your.company.com"
+      docker-registry = "registry.service.texas.your.company.com/whatever"
+
+      infrastructure {
+        # values can be "kubernetes" | "nomad"
+        scheduler = "nomad"
+        # values can be "kubernetes" | "consul" | "consul:lighthouse" | "noop"
+        routing = "consul:lighthouse"
+
+        kubernetes {
+          in-cluster = false
+          timeout    = 3 seconds
+          kubeconfig = "/opt/application/conf/kubeconfig"
+        }
+
+        nomad {
+          endpoint = "http://nomad.service.texas.your.company.com:1234/"
+          timeout = 1 second
+          docker {
+            host = "registry.service.texas.your.company.com"
+            user = "someuser"
+            password = "dummypwd"
+          }
+        }
+
+        consul {
+          endpoint  = "http://consul.service.texas.your.company.com"
+          timeout   = 1 second
+          acl-token = "XXXXXXXXX"
+          username  = "XXXXXXXXX"
+          password  = "XXXXXXXXX"
+        }
+
+        vault {
+          endpoint   = "https://vault.service.texas.your.company.com:1234"
+          auth-token = "XXXXXXXXX"
+          timeout    = 5 seconds
+          # optional: if your backend auth provider (for kubernetes, as one example)
+          # has the same name as the datacenter, you can ignore this field. Given
+          # this is not typically the case (people have some convention) then you can
+          # specify a prefix that will be prepended to the datacenter name:
+          auth-role-prefix = "aws-"
+        }
+
+        loadbalancer {
+          aws {
+             # access-key-id and secret-access-key are OPTIONAL
+             # one can use the IAM instance provider
+             access-key-id = "XXXXXXXXX"
+             secret-access-key = "XXXXXXXXX"
+             region = "texas"
+             launch-configuration-name = "nelson-lb-1-LaunchConfig-XXXXXXXXXXXXXXXXXX"
+             # image is optional
+             image = "registry.service.texas.your.company.com/whatever/infra-lb:1.2.3"
+             elb-security-group-names = [ "sg-AAAAAAAA", "sg-BBBBBBB" ]
+             availability-zones {
+               texas-a {
+                 private-subnet = "subnet-AAAAAAAA"
+                 public-subnet = "subnet-BBBBBBB"
+               }
+             }
+          }
+        }
+      }
+      policy {
+        # Path under which credentials are stored for
+        # resources.  Units will get read capability on each resource.
+        # Supported variables: %env%, %resource%, %unit%
+        resource-creds-path = "nelson/%env%/%resource%/creds/%unit%"
+
+        # Path to your PKI backend. Optional. If specified, unit will get
+        # create and update capabilities on ${pki-path}/issue
+        # Supported variables: %env%
+        # pki-path = "pki"
+      }
+    }
+  }
 }

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -561,7 +561,7 @@ object Config {
     def readNomadScheduler(kfg: KConfig): IO[SchedulerOp ~> IO] =
       readNomadInfrastructure(kfg) match {
         case Some(n) => http4sClient(n.timeout).map(client => new scheduler.NomadHttp(nomadcfg, n, client, schedulerPool, ec))
-        case None    => IO.raiseError(new IllegalArgumentException("At least one scheduler must be defined per datacenter"))
+        case None    => IO.raiseError(new IllegalArgumentException("Unable to parse the nomad scheduler configuration"))
       }
 
     @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.NoNeedForMonad"))

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -595,68 +595,72 @@ object Config {
        * used in place of the real interpreter.
        */
       def consulRouting: IO[helm.ConsulOp ~> IO] = {
-        val isEnabled = kfg.lookup[String]("infrastructure.consul.endpoint").nonEmpty
-        if (isEnabled){
-          // if you're using consul, you must specify the timeout and the endpoint.
-          // these are non-optional.
-          val a = kfg.require[String]("infrastructure.consul.endpoint")
-          val b = kfg.require[Duration]("infrastructure.consul.timeout")
-          val c = kfg.lookup[String]("infrastructure.consul.acl-token")
-          val d = kfg.lookup[String]("infrastructure.consul.username")
-          val e = kfg.lookup[String]("infrastructure.consul.password")
-          val client = http4sClient(b, 20)
+        // if you're using consul, you must specify the timeout and the endpoint.
+        // these are non-optional.
+        val a = kfg.require[String]("infrastructure.consul.endpoint")
+        val b = kfg.require[Duration]("infrastructure.consul.timeout")
+        val c = kfg.lookup[String]("infrastructure.consul.acl-token")
+        val d = kfg.lookup[String]("infrastructure.consul.username")
+        val e = kfg.lookup[String]("infrastructure.consul.password")
+        val client = http4sClient(b, 20)
 
-          val http4sConsul = (d,e) match {
-            case (None,None) => client.map(consulClient => Http4sConsul.client(Infrastructure.Consul(new URI(a), b, c, None), consulClient))
-            case (Some(u),Some(pw)) =>
-              client.map(consulClient => Http4sConsul.client(Infrastructure.Consul(new URI(a), b, c,
-                Some(Infrastructure.Credentials(u,pw))), consulClient))
-            case _ =>
-              log.error("If you configure the datacenter to have a consul username, or consul password, it must have both.")
-              client.map(consulClient => Http4sConsul.client(Infrastructure.Consul(new URI(a), b, c, None), consulClient))
-          }
-          http4sConsul.map(consulClient => PrometheusConsul(a, consulClient))
-        } else {
-          IO.pure(StubbedConsulClient)
+        val http4sConsul = (d,e) match {
+          case (None,None) => client.map(consulClient => Http4sConsul.client(Infrastructure.Consul(new URI(a), b, c, None), consulClient))
+          case (Some(u),Some(pw)) =>
+            client.map(consulClient => Http4sConsul.client(Infrastructure.Consul(new URI(a), b, c,
+              Some(Infrastructure.Credentials(u,pw))), consulClient))
+          case _ =>
+            log.error("If you configure the datacenter to have a consul username, or consul password, it must have both.")
+            client.map(consulClient => Http4sConsul.client(Infrastructure.Consul(new URI(a), b, c, None), consulClient))
         }
+        http4sConsul.map(consulClient => PrometheusConsul(a, consulClient))
       }
 
-      val schedConfig = kfg.subconfig("infrastructure.scheduler")
+      def withKubectl[A](f: (Kubectl, FiniteDuration) => IO[A]): IO[A] =
+        readKubernetesInfrastructure(kfg.subconfig("infrastructure.kubernetes")) match {
+          case Some(Infrastructure.Kubernetes(mode, timeout)) =>
+            val kubectl = new Kubectl(mode)
+            f(kubectl, timeout)
+          case None => IO.raiseError(new IllegalArgumentException("both 'in-cluster' and 'timeout' must be specified when using the kubernetes scheduler"))
+        }
 
-      val components = schedConfig.lookup[String]("scheduler") match {
-        case Some("nomad") =>
-          // for {
-          //   consulClient  <- consulRouting
-          //   sched         <- readNomadScheduler(schedConfig.subconfig("nomad"))
-          //   healthChecker = health.Http4sConsulHealthClient(consulClient)
-          // } yield (sched, healthChecker, consulClient)
-          IO.raiseError(NomadNotImplemented)
+      val scheduling: IO[SchedulerOp ~> IO] = kfg.lookup[String]("infrastructure.scheduler") match {
+        case Some("kubernetes") => {
+          withKubectl((kubectl, timeout) =>
+            IO.pure(new KubernetesShell(kubectl, timeout, ec, schedulerPool)))
+        }
+        case Some("nomad") => IO.raiseError(NomadNotImplemented)
+        case _ => IO.raiseError(new IllegalArgumentException("At least one scheduler must be defined per datacenter"))
+      }
 
-        case Some("kubernetes") =>
-          readKubernetesInfrastructure(schedConfig.subconfig("kubernetes")) match {
-            case Some(Infrastructure.Kubernetes(mode, timeout)) =>
-              val kubectl = new Kubectl(mode)
-              consulRouting.map { consul =>
-                (
-                  new KubernetesShell(kubectl, timeout, ec, schedulerPool),
-                  new KubernetesHealthClient(kubectl, timeout, ec, schedulerPool),
-                  consul
-                )
-              }
-            case None => IO.raiseError(new IllegalArgumentException("At least one scheduler must be defined per datacenter"))
-          }
+      // however you decide to do routing, you need to account for how you figure out
+      // if a given stack is "ready" or is still "warming"
+      val routing: IO[(helm.ConsulOp ~> IO, health.HealthCheckOp ~> IO)] =
+        kfg.lookup[String]("infrastructure.routing") match {
+          case Some("consul") | Some("consul:lighthouse") => for {
+            a <- consulRouting
+            b <- IO.pure(health.Http4sConsulHealthClient(a))
+          } yield (a,b)
 
-        case _ => IO.raiseError(new IllegalArgumentException(s"At least one scheduler must be defined per datacenter"))
+          case Some("kubernetes") => for {
+            a <- IO.pure(StubbedConsulClient)
+            b <- withKubectl((kubectl, timeout) =>
+              IO.pure(new KubernetesHealthClient(kubectl, timeout, ec, schedulerPool)))
+          } yield (a,b)
+
+          case Some("noop") | None => IO.pure((StubbedConsulClient, health.StubbedHealthClient))
+          case Some(unknown) => IO.raiseError(new IllegalArgumentException(s"The specified routing configuration '${unknown}' is not a valid routing sub-system"))
       }
 
       val interpreters = for {
-        comp <- components
-        (sched, healthChecker, consul) = comp
-        vv   <- vault
+        sched <- scheduling
+        expand <- routing
+        (router, healthChecker) = expand
+        vv <- vault
       } yield {
         Infrastructure.Interpreters(
           scheduler = sched,
-          consul = consul,
+          consul = router,
           vault = vv,
           storage = stg,
           logger = logger,

--- a/core/src/main/scala/health/StubbedHealthClient.scala
+++ b/core/src/main/scala/health/StubbedHealthClient.scala
@@ -1,0 +1,12 @@
+package nelson
+package health
+
+import nelson.health.HealthCheckOp._
+import cats.~>
+import cats.effect.IO
+
+final object StubbedHealthClient extends (HealthCheckOp ~> IO) {
+  def apply[A](fa: HealthCheckOp[A]): IO[A] = fa match {
+    case Health(dc, ns, stackName) => IO.pure(Nil)
+  }
+}

--- a/core/src/test/resources/nelson/datacenters-missing-domain.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-domain.cfg
@@ -28,13 +28,13 @@ nelson {
       }
 
       infrastructure {
-        scheduler {
-          scheduler = "kubernetes"
-          kubernetes {
-            in-cluster = true
-            timeout = 1 second
-          }
+        scheduler = "kubernetes"
+
+        kubernetes {
+          in-cluster = true
+          timeout = 1 second
         }
+
         consul {
           endpoint  = "https://consul.service"
           timeout   = 1 second

--- a/core/src/test/resources/nelson/datacenters.cfg
+++ b/core/src/test/resources/nelson/datacenters.cfg
@@ -28,13 +28,13 @@ nelson {
         duration = 2 minute
       }
       infrastructure {
-        scheduler {
-          scheduler = "kubernetes"
-          kubernetes {
-            in-cluster = true
-            timeout = 1 second
-          }
+        scheduler = "kubernetes"
+
+        kubernetes {
+          in-cluster = true
+          timeout = 1 second
         }
+
         consul {
           endpoint  = "https://consul.service"
           timeout   = 1 second
@@ -73,14 +73,13 @@ nelson {
       }
 
       infrastructure {
+        scheduler = "kubernetes"
+        routing = "consul"
 
-        scheduler {
-          scheduler = "kubernetes"
-          kubernetes {
-            in-cluster = false
-            kubeconfig = "/foo/bar/.kube/config"
-            timeout = 2 seconds
-          }
+        kubernetes {
+          in-cluster = false
+          kubeconfig = "/foo/bar/.kube/config"
+          timeout = 2 seconds
         }
 
         consul {

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
 //:   limitations under the License.
 //:
 //: ----------------------------------------------------------------------------
-version in ThisBuild := "0.12.0-SNAPSHOT"
+version in ThisBuild := "0.13.0-SNAPSHOT"


### PR DESCRIPTION
This PR includes a significant refactor of how we configure the infrastructure block of the config file. Specifically, the following 0.12 config:

```
infrastructure {
  scheduler {
    scheduler = "nomad"
    kubernetes {
      in-cluster = false
      timeout    = 10 seconds
      kubeconfig = "/opt/application/conf/kubeconfig"
    }
   # and nomad if configured
  }
}
``` 
This now becomes:

```
infrastructure {
  # values can be "kubernetes" | "nomad"
  scheduler = "nomad"
  # values can be "kubernetes" | "consul" | "consul:lighthouse" | "noop"
  routing = "consul:lighthouse"
  kubernetes {
    in-cluster = false
    timeout    = 3 seconds
    kubeconfig = "/opt/application/conf/kubeconfig"
  }
  # and nomad etc...
}
```

The specific change here is that the configuration is now more explicit, as we found that Nelson cannot possibly infer all combinations of the sparse matrix therein. 

