### PR TITLE
Raise hell if the names are empty or the template is bad

### DIFF
--- a/etc/development/http/http.dev.cfg
+++ b/etc/development/http/http.dev.cfg
@@ -85,12 +85,12 @@ nelson {
       }
 
       infrastructure {
-        scheduler {
-          scheduler = "kubernetes"
-          kubernetes {
-            in-cluster = true
-            timeout = 1 second
-          }
+        scheduler = "kubernetes"
+        routing = "consul:lighthouse"
+
+        kubernetes {
+          in-cluster = true
+          timeout = 1 second
         }
         consul {
           endpoint  = "https://consul.service"

--- a/http/src/main/scala/plans/Blueprints.scala
+++ b/http/src/main/scala/plans/Blueprints.scala
@@ -147,10 +147,10 @@ final case class Blueprints(config: NelsonConfig) extends Default {
     case req @ POST -> Root / "v1" / "blueprints" & IsAuthenticated(session) if IsAuthorized(session) =>
       decode[BlueprintRequestJson](req){ bpr =>
         if (hasIntegrity(bpr.sha256, bpr.template))
-          if (Option(bpr.name).exists(_ != ""))
+          if (Option(bpr.name).exists(_.trim.nonEmpty))
             json(Nelson.createBlueprint(bpr.name, bpr.description, bpr.sha256, bpr.template))
           else
-            BadRequest(s"Blueprints must have a name, otherwise uesrs will not be able to reference them.")
+            BadRequest(s"Blueprints must have a name, otherwise users will not be able to reference them.")
         else
           BadRequest(s"The supplied Sha256 for decoded template content did not match the computed Sha256.")
       }

--- a/http/src/main/scala/plans/Blueprints.scala
+++ b/http/src/main/scala/plans/Blueprints.scala
@@ -147,7 +147,7 @@ final case class Blueprints(config: NelsonConfig) extends Default {
     case req @ POST -> Root / "v1" / "blueprints" & IsAuthenticated(session) if IsAuthorized(session) =>
       decode[BlueprintRequestJson](req){ bpr =>
         if (hasIntegrity(bpr.sha256, bpr.template))
-          if (Option(bpr.name).nonEmpty)
+          if (Option(bpr.name).exists(_ != ""))
             json(Nelson.createBlueprint(bpr.name, bpr.description, bpr.sha256, bpr.template))
           else
             BadRequest(s"Blueprints must have a name, otherwise uesrs will not be able to reference them.")

--- a/http/src/main/scala/plans/Blueprints.scala
+++ b/http/src/main/scala/plans/Blueprints.scala
@@ -147,7 +147,10 @@ final case class Blueprints(config: NelsonConfig) extends Default {
     case req @ POST -> Root / "v1" / "blueprints" & IsAuthenticated(session) if IsAuthorized(session) =>
       decode[BlueprintRequestJson](req){ bpr =>
         if (hasIntegrity(bpr.sha256, bpr.template))
-          json(Nelson.createBlueprint(bpr.name, bpr.description, bpr.sha256, bpr.template))
+          if (Option(bpr.name).nonEmpty)
+            json(Nelson.createBlueprint(bpr.name, bpr.description, bpr.sha256, bpr.template))
+          else
+            BadRequest(s"Blueprints must have a name, otherwise uesrs will not be able to reference them.")
         else
           BadRequest(s"The supplied Sha256 for decoded template content did not match the computed Sha256.")
       }


### PR DESCRIPTION
Got into a sticky situation where a user uploaded a template that was not parsable, breaking all the templating listing and inspection capabilities. This PR adds more validation to the server side to prevent these kinds of accidents 