### PR TITLE
Have the ability to specify an ELB as internal

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -291,6 +291,7 @@ nelson {
   #            # image is optional
   #            image = "registry.service.texas.your.company.com/whatever/infra-lb:1.2.3"
   #            elb-security-group-names = [ "sg-AAAAAAAA", "sg-BBBBBBB" ]
+  #            use-internal-elb = true
   #            availability-zones {
   #              texas-a {
   #                private-subnet = "subnet-AAAAAAAA"

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -701,6 +701,10 @@ object Config {
       )
     }
 
+    /*
+     * if no scheme is supplied, then the default is to assume internet-facing
+     * loadbalancers, maintaining the existing default functionality.
+     */
     def lookupElbScheme(k: KConfig): Option[ElbScheme] =
       k.lookup[Boolean]("use-internal-elb").map(useInternal =>
         if(useInternal) ElbScheme.Internal
@@ -736,7 +740,7 @@ object Config {
     (lookupRegion(kfg),
      kfg.lookup[String]("launch-configuration-name"),
      kfg.lookup[List[String]]("elb-security-group-names"),
-     lookupElbScheme(kfg)
+     lookupElbScheme(kfg) orElse Some(ElbScheme.External)
     ).mapN((a,b,c,d) => Infrastructure.Aws(creds,a,b,c.toSet,zones,kfg.lookup[String]("image"),d))
   }
 

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -114,7 +114,8 @@ object Infrastructure {
     launchConfigurationName: String,
     elbSecurityGroupNames: Set[String],
     availabilityZones: Set[AvailabilityZone] = Set.empty,
-    image: Option[String]
+    image: Option[String],
+    lbScheme: loadbalancers.ElbScheme
   ) {
     import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
     import com.amazonaws.services.autoscaling.AmazonAutoScalingClient

--- a/core/src/main/scala/loadbalancers/Aws.scala
+++ b/core/src/main/scala/loadbalancers/Aws.scala
@@ -32,9 +32,8 @@ import journal.Logger
 
 final case class ASGSize(desired: Int, min: Int, max: Int)
 
-/**
+/*
  * Modeling the internal vs internet ELB schemes
- * @url https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/elasticloadbalancing/model/CreateLoadBalancerRequest.html#withScheme-java.lang.String-
  */
 sealed trait ElbScheme
 final object ElbScheme {

--- a/core/src/test/resources/nelson/datacenters-valid-aws.cfg
+++ b/core/src/test/resources/nelson/datacenters-valid-aws.cfg
@@ -1,0 +1,28 @@
+##: ----------------------------------------------------------------------------
+##: Copyright (C) 2017 Verizon.  All Rights Reserved.
+##:
+##:   Licensed under the Apache License, Version 2.0 (the "License");
+##:   you may not use this file except in compliance with the License.
+##:   You may obtain a copy of the License at
+##:
+##:       http://www.apache.org/licenses/LICENSE-2.0
+##:
+##:   Unless required by applicable law or agreed to in writing, software
+##:   distributed under the License is distributed on an "AS IS" BASIS,
+##:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##:   See the License for the specific language governing permissions and
+##:   limitations under the License.
+##:
+##: ----------------------------------------------------------------------------
+aws {
+  region = "us-west-2"
+  launch-configuration-name = "sdfsdfdsf"
+  elb-security-group-names = [ "sg-123", "sg-456" ]
+  use-internal-elb = true
+  availability-zones {
+    texas {
+      private-subnet = "subnet-xxxx"
+      public-subnet = "subnet-yyyyy"
+    }
+  }
+}

--- a/core/src/test/resources/nelson/datacenters.cfg
+++ b/core/src/test/resources/nelson/datacenters.cfg
@@ -98,6 +98,7 @@ nelson {
               "elb-security-group-test",
               "elb-security-group-test2"
             ]
+            use-internal-elb = true
             image = "docker/image:1.1.1"
             availability-zones {
               us-west-2a {

--- a/core/src/test/scala/ConfigSpec.scala
+++ b/core/src/test/scala/ConfigSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.{FlatSpec,Matchers}
 import cats.effect.IO
 import cats.implicits._
 import nelson.Util._
+import loadbalancers.ElbScheme
 
 class ConfigSpec extends FlatSpec with Matchers {
 
@@ -58,11 +59,19 @@ class ConfigSpec extends FlatSpec with Matchers {
       msg == "No such key: public-subnet"
     } should equal (true)
   }
+
   it should "fail if private subnet is not specified in aws config" in {
     val cfg = readAws("nelson/datacenters-missing-private-subnet.cfg").attempt.unsafeRunSync()
     cfg.swap.exists { err =>
       val msg = err.getMessage
       msg == "No such key: private-subnet"
+    } should equal (true)
+  }
+
+  it should "successfully read the aws config" in {
+    val cfg = readAws("nelson/datacenters-valid-aws.cfg").attempt.unsafeRunSync()
+    cfg.right.exists { c =>
+      c.map(_.lbScheme) == Some(ElbScheme.Internal)
     } should equal (true)
   }
 

--- a/docs/src/hugo/content/documentation/configuration.md
+++ b/docs/src/hugo/content/documentation/configuration.md
@@ -569,6 +569,7 @@ In order to enable Nelson's support for dynamically provisioning load-balencers 
 * [loadbalancer.aws.launch-configuration-name](#loadbalancer-aws-launch-configuration-name)
 * [loadbalancer.aws.region](#loadbalancer-aws-region)
 * [loadbalancer.aws.secret-access-key](#loadbalancer-aws-secret-access-key)
+* [loadbalancer.aws.use-internal-elb](#loadbalancer-use-internal-elb)
 
 #### loadbalancer.aws.access-key-id
 
@@ -634,6 +635,14 @@ To provide Nelson access to AWS to launch the needed resources, provide an AWS a
 
 ```
 datacenter.texas.infrastructure.loadbalancer.aws.secret-access-key = "XXXXXXXXX"
+```
+
+#### loadbalancer.aws.use-internal-elb
+
+Depending on your network topology, it can sometimes be desirable to have Nelson spawn internal ELBs, which are not exposed to the internet (and cannot be exposed). In this case, Nelson assumes that you have some kind of VPN or other network route to reach these ELBs.
+
+```
+datacenter.texas.infrastructure.loadbalancer.aws.use-internal-elb = true
 ```
 
 ----


### PR DESCRIPTION
This adds the ability to specify that the ELB that nelson launches is `internal`. For more information see: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-internal-load-balancers.html