### PR TITLE
k8s: Use contexts instead of namespaces for flexibility 

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -239,7 +239,6 @@ nelson {
   #       scheduler {
   #         scheduler = "nomad"
   #         kubernetes {
-  #           in-cluster = false
   #           timeout    = 10 seconds
   #           kubeconfig = "/opt/application/conf/kubeconfig"
   #         }

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -73,21 +73,9 @@ object Infrastructure {
   )
 
   final case class Kubernetes(
-    mode: KubernetesMode,
+    kubeconfig: Path,
     timeout: FiniteDuration
   )
-
-  sealed abstract class KubernetesMode extends Product with Serializable {
-    def environment: List[(String, String)] = this match {
-      case KubernetesMode.InCluster => List.empty
-      case KubernetesMode.OutCluster(path) => List(("KUBECONFIG", path.toString))
-    }
-  }
-
-  object KubernetesMode {
-    final case object InCluster extends KubernetesMode
-    final case class OutCluster(kubeconfig: Path) extends KubernetesMode
-  }
 
   final case class Credentials(
     username: String,

--- a/core/src/main/scala/Kubectl.scala
+++ b/core/src/main/scala/Kubectl.scala
@@ -21,18 +21,18 @@ import scala.collection.mutable.ListBuffer
 final class Kubectl(mode: KubernetesMode) {
   import Kubectl._
 
-  def apply(payload: String): IO[String] = {
+  def apply(payload: String, namespace: NamespaceName): IO[String] = {
     val input = IO { new ByteArrayInputStream(payload.getBytes(UTF_8)) }
     for {
-      result <- exec(List("kubectl", "apply", "-f", "-"), input)
+      result <- exec(List("kubectl", "apply", "--context", namespace.root.asString, "-f", "-"), input)
       output <- result.output
     } yield output.mkString("\n")
   }
 
-  def delete(payload: String): IO[String] = {
+  def delete(payload: String, namespace: NamespaceName): IO[String] = {
     val input = IO { new ByteArrayInputStream(payload.getBytes(UTF_8)) }
     for {
-      result <- exec(List("kubectl", "delete", "-f", "-"), input)
+      result <- exec(List("kubectl", "delete", "--context", namespace.root.asString, "-f", "-"), input)
       output <- result.output
     } yield output.mkString("\n")
   }
@@ -53,7 +53,7 @@ final class Kubectl(mode: KubernetesMode) {
 
   def getPods(namespace: NamespaceName, stackName: StackName): IO[List[HealthStatus]] = {
     implicit val healthStatusDecoder = healthStatusDecodeJson
-    exec(List("kubectl", "get", "pods", "-l", s"stackName=${stackName.toString}", "-n", namespace.root.asString, "-o", "json"), emptyStdin)
+    exec(List("kubectl", "get", "pods", "-l", s"stackName=${stackName.toString}", "--context", namespace.root.asString, "-o", "json"), emptyStdin)
       .flatMap(_.output)
       .flatMap { stdout =>
         IO.fromEither(for {
@@ -64,14 +64,14 @@ final class Kubectl(mode: KubernetesMode) {
   }
 
   def getDeployment(namespace: NamespaceName, stackName: StackName): IO[DeploymentStatus] =
-    exec(List("kubectl", "get", "deployment", stackName.toString, "-n", namespace.root.asString, "-o", "json"), emptyStdin)
+    exec(List("kubectl", "get", "deployment", stackName.toString, "--context", namespace.root.asString, "-o", "json"), emptyStdin)
       .flatMap(_.output)
       .flatMap { stdout =>
         IO.fromEither(Parse.decodeEither[DeploymentStatus](stdout.mkString("\n")).leftMap(kubectlJsonError))
       }
 
   def getCronJob(namespace: NamespaceName, stackName: StackName): IO[JobStatus] =
-    exec(List("kubectl", "get", "job", "-l", s"stackName=${stackName.toString}", "-n", namespace.root.asString, "-o", "json"), emptyStdin)
+    exec(List("kubectl", "get", "job", "-l", s"stackName=${stackName.toString}", "--context", namespace.root.asString, "-o", "json"), emptyStdin)
       .flatMap(_.output)
       .flatMap { stdout =>
         IO.fromEither(for {
@@ -81,14 +81,14 @@ final class Kubectl(mode: KubernetesMode) {
       }
 
   def getJob(namespace: NamespaceName, stackName: StackName): IO[JobStatus] =
-    exec(List("kubectl", "get", "job", stackName.toString, "-n", namespace.root.asString, "-o", "json"), emptyStdin)
+    exec(List("kubectl", "get", "job", stackName.toString, "--context", namespace.root.asString, "-o", "json"), emptyStdin)
       .flatMap(_.output)
       .flatMap { stdout =>
         IO.fromEither(Parse.decodeEither[JobStatus](stdout.mkString("\n")).leftMap(kubectlJsonError))
       }
 
   private def deleteV1(namespace: String, objectType: String, name: String): IO[Output] =
-    exec(List("kubectl", "delete", objectType, name, "-n", namespace), emptyStdin)
+    exec(List("kubectl", "delete", objectType, name, "--context", namespace), emptyStdin)
 
   private def exec(cmd: List[String], stdin: IO[InputStream]): IO[Output] = {
     // We need the new cats-effect resource safety hotness..

--- a/core/src/main/scala/scheduler/KubernetesShell.scala
+++ b/core/src/main/scala/scheduler/KubernetesShell.scala
@@ -58,7 +58,7 @@ final class KubernetesShell(
         }
       }
 
-    deployment.renderedBlueprint.fold(fallback)(spec => kubectl.delete(spec).void)
+    deployment.renderedBlueprint.fold(fallback)(spec => kubectl.delete(spec, ns).void)
   }
 
   // Janky heuristic to see if an attempted (legacy) deletion failed because
@@ -89,7 +89,7 @@ final class KubernetesShell(
 
     for {
       t <- template
-      r <- kubectl.apply(t.render(env))
+      r <- kubectl.apply(t.render(env), ns)
     } yield r
   }
 

--- a/core/src/test/resources/nelson/datacenters-missing-consul.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-consul.cfg
@@ -32,7 +32,7 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            in-cluster = true
+            kubeconfig = "~/.kube/config"
             timeout = 1 second
           }
         }
@@ -68,7 +68,7 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            in-cluster = true
+            kubeconfig = /foo/bar/.kube/config
             timeout = 1 second
           }
         }

--- a/core/src/test/resources/nelson/datacenters-missing-domain.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-domain.cfg
@@ -31,7 +31,7 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            in-cluster = true
+            kubeconfig = "~/.kube/config"
             timeout = 1 second
           }
         }

--- a/core/src/test/resources/nelson/datacenters.cfg
+++ b/core/src/test/resources/nelson/datacenters.cfg
@@ -31,7 +31,7 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            in-cluster = true
+            kubeconfig = "~/.kube/config"
             timeout = 1 second
           }
         }
@@ -77,7 +77,6 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            in-cluster = false
             kubeconfig = "/foo/bar/.kube/config"
             timeout = 2 seconds
           }

--- a/docs/src/hugo/content/getting-started/install.md
+++ b/docs/src/hugo/content/getting-started/install.md
@@ -186,13 +186,10 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            # is nelson hosted on the cluster it is managing?
-            in-cluster = false
-            # in the event that Nelson is running on a substrate
-            # outside of the deployment clusters, specify the path
-            # to the kubeconfig which will dictate how kubectl does
-            # authentication with the cluster and so forth.
+            # specify the path to the kubeconfig which will dictate
+            # kubectl do authentication with the cluster and so forth.
             kubeconfig = /path/to/.kube/config
+            timeout = 10 seconds
           }
         }
 

--- a/etc/development/http/http.dev.cfg
+++ b/etc/development/http/http.dev.cfg
@@ -93,7 +93,7 @@ nelson {
         scheduler {
           scheduler = "kubernetes"
           kubernetes {
-            in-cluster = true
+            kubeconfig = "~/.kube/config"
             timeout = 1 second
           }
         }


### PR DESCRIPTION
NOTE: This is a breaking change for in-cluster deployments, more info below:

Using the --namespace flag assumes the "current" credentials are valid
for that namespace (e.g. kubectl does not try to switch contexts when
you explicitly specify a namespace, which makes sense). However it is
possible that a Kubernetes deployment expects different credentials
per-namespace, which KUBECONFIG supports. However given how we're using
--namespace right now, Nelson isn't leveraging that flexibility.

This change instead uses --context to explicitly specify the context
(and therefore token + namespace). However since contexts can be named
anything (there is a logical name for each context which ties together
(cluster, namespace, token)), and because we expect each DC to have
its own KUBECONFIG, Nelson will assume the context name is the same as
the namespace name.

In addition this change also removes in/out-cluster distinction in the Kubernetes backend.

Previous in-cluster behavior used assumed administrative credentials
automatically mounted in the Pod
(https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
to do deployments in-cluster. However with the previous change to use
--context instead of --namespace, this no longer works (because there is
no KUBECONFIG file, it just uses the token). Therefore even if Nelson
is deployed in the same cluster a corresponding kubeconfig must still be
mounted + specified. In any case this also makes the semantics perhaps
slightly less confusing and/or more consistent.