### PR TITLE
Create PKI roles so services can create certificates

### DIFF
--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -61,6 +61,8 @@ final class Http4sVaultClient(
     case ct: CreateToken          => createToken(ct)
     case kr: CreateKubernetesRole => createKubernetesRole(kr)
     case dr: DeleteKubernetesRole => deleteKubernetesRole(dr)
+    case cpkir: CreatePKIRole     => createPKIRole(cpkir)
+    case dpkir: DeletePKIRole     => deletePKIRole(dpkir)
   }
 
   val log = Logger[this.type]
@@ -150,4 +152,14 @@ final class Http4sVaultClient(
 
   private def kubernetesAuthEngineName(cn: String): String =
     authBackendPrefix.map(_ + cn).getOrElse(cn)
+
+  def createPKIRole(cpkir: CreatePKIRole): IO[Unit] = {
+    val engine = kubernetesAuthEngineName(cpkir.engineName)
+    reqVoid(IO.pure(Request(POST, v1BaseUri / engine / "roles" / cpkir.roleName)))
+  }
+
+  def deletePKIRole(dpkir: DeletePKIRole): IO[Unit] = {
+    val engine = kubernetesAuthEngineName(cpkir.engineName)
+    reqVoid(IO.pure(Request(DELETE, v1BaseUri / engine / "roles" / cpkir.roleName)))
+  }
 }

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -114,4 +114,13 @@ trait Json {
       ("policies" :?= kr.policies) ->?:
       jEmptyObject
     }
+
+    implicit val jsonCreatePKIRole: EncodeJson[CreatePKIRole] =
+    EncodeJson { cpkir =>
+      ("name" := cpkir.serviceAccountNames) ->:
+      ("ttl" :?= cpkir.defaultLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
+      ("max_ttl" :?= cpkir.maxLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
+      ("allow_localhost" :?= cpkir.allowLocalhost) ->?:
+      jEmptyObject
+    }
 }

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -130,6 +130,15 @@ object Vault {
     roleName: String
   ): VaultF[Unit] = Free.liftF(DeleteKubernetesRole(authClusterName, roleName))
 
+  // TODO(drewgonzales360): Do some sort of validation to ensure the roleName is a unitName
+  def createPKIRole(
+    roleName: String
+  ): VaultF[Unit] = Free.liftF(createPKIRole(roleName))
+
+  def deletePKIRole(
+    roleName: String
+  ): VaultF[Unit] = Free.liftF(deletePKIRole(roleName))
+
   case object IsInitialized extends Vault[Boolean]
   final case class Initialize(init: Initialization) extends Vault[InitialCreds]
   final case class Unseal(key: MasterKey) extends Vault[SealStatus]
@@ -151,4 +160,3 @@ object Vault {
     policies: Option[List[String]]) extends Vault[Unit]
   final case class DeleteKubernetesRole(authClusterName: String, roleName: String) extends Vault[Unit]
 }
-


### PR DESCRIPTION
In Vault, the [PKI engine](https://www.vaultproject.io/api/secret/pki/index.html) requires that a role be [created](https://www.vaultproject.io/api/secret/pki/index.html#create-update-role) so that certificates can be issued against it. When certs are issued, services that take ingress traffic can TLS secured. 

This PR adds functionality to create these roles. 