### PR TITLE
Upgrade from launch configurations to launch templates

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -48,8 +48,8 @@ libraryDependencies ++= Seq(
   "org.typelevel"              %% "cats-kernel-laws"                   % V.cats   % "test",
   "org.apache.commons"          % "commons-email"                      % "1.3.3",
   "commons-codec"               % "commons-codec"                      % "1.11",
-  "com.amazonaws"               % "aws-java-sdk-autoscaling"           % "1.11.25",
-  "com.amazonaws"               % "aws-java-sdk-elasticloadbalancing"  % "1.11.25",
+  "com.amazonaws"               % "aws-java-sdk-autoscaling"           % "1.11.595",
+  "com.amazonaws"               % "aws-java-sdk-elasticloadbalancing"  % "1.11.595",
   "com.google.guava"            % "guava"                              % "20.0",
   "com.google.code.findbugs"    % "jsr305"                             % "3.0.1", // needed to provide class javax.annotation.Nullable
   "com.cronutils"               % "cron-utils"                         % "5.0.5",

--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -287,7 +287,7 @@ nelson {
   #            access-key-id = "XXXXXXXXX"
   #            secret-access-key = "XXXXXXXXX"
   #            region = "texas"
-  #            launch-configuration-name = "nelson-lb-1-LaunchConfig-XXXXXXXXXXXXXXXXXX"
+  #            launch-template-id = "lt-XXXXXXXXXXX"
   #            # image is optional
   #            image = "registry.service.texas.your.company.com/whatever/infra-lb:1.2.3"
   #            elb-security-group-names = [ "sg-AAAAAAAA", "sg-BBBBBBB" ]

--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -29,8 +29,8 @@ import nelson.storage.StoreOp
 import nelson.vault._
 import nelson.vault.http4s._
 
-import com.amazonaws.auth.{AWSCredentialsProviderChain, BasicAWSCredentials, EC2ContainerCredentialsProviderWrapper}
-import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, AWSStaticCredentialsProvider, BasicAWSCredentials, EC2ContainerCredentialsProviderWrapper}
 
 import cats.~>
 import cats.effect.{Effect, IO}
@@ -728,7 +728,7 @@ object Config {
       val basic = for {
         ak <- kfg.lookup[String]("access-key-id")
         sk <- kfg.lookup[String]("secret-access-key")
-      } yield new StaticCredentialsProvider(new BasicAWSCredentials(ak, sk))
+      } yield new AWSStaticCredentialsProvider(new BasicAWSCredentials(ak, sk))
 
       val ec2Discovery = Option(new EC2ContainerCredentialsProviderWrapper())
 
@@ -738,7 +738,7 @@ object Config {
     val creds = buildProviderChain(kfg)
 
     (lookupRegion(kfg),
-     kfg.lookup[String]("launch-configuration-name"),
+     kfg.lookup[String]("launch-template-id"),
      kfg.lookup[List[String]]("elb-security-group-names"),
      lookupElbScheme(kfg) orElse Some(ElbScheme.External)
     ).mapN((a,b,c,d) => Infrastructure.Aws(creds,a,b,c.toSet,zones,kfg.lookup[String]("image"),d))

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -111,20 +111,26 @@ object Infrastructure {
   final case class Aws(
     private val creds: AWSCredentialsProviderChain,
     region: Region,
-    launchConfigurationName: String,
+    launchTemplateId: String,
     elbSecurityGroupNames: Set[String],
     availabilityZones: Set[AvailabilityZone] = Set.empty,
     image: Option[String],
     lbScheme: loadbalancers.ElbScheme
   ) {
-    import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
-    import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
+    import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder
+    import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder
 
-    val asg = new AmazonAutoScalingClient(creds)
-      .withRegion[AmazonAutoScalingClient](region)
+    val asg = AmazonAutoScalingClientBuilder
+      .standard
+      .withCredentials(creds)
+      .withRegion(region.getName)
+      .build()
 
-    val elb = new AmazonElasticLoadBalancingClient(creds)
-      .withRegion[AmazonElasticLoadBalancingClient](region)
+    val elb = AmazonElasticLoadBalancingClientBuilder
+      .standard
+      .withCredentials(creds)
+      .withRegion(region.getName)
+      .build()
   }
 
   final case class TrafficShift(

--- a/core/src/test/resources/nelson/datacenters-aws-missing-elb-scheme.cfg
+++ b/core/src/test/resources/nelson/datacenters-aws-missing-elb-scheme.cfg
@@ -16,7 +16,7 @@
 ##: ----------------------------------------------------------------------------
 aws {
   region = "us-west-2"
-  launch-configuration-name = "sdfsdfdsf"
+  launch-template-id = "sdfsdfdsf"
   elb-security-group-names = [ "sg-123", "sg-456" ]
   availability-zones {
     texas {

--- a/core/src/test/resources/nelson/datacenters-missing-private-subnet.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-private-subnet.cfg
@@ -18,7 +18,7 @@
    access-key-id = "key"
    secret-access-key = "secret"
    region = "texas"
-   launch-configuration-name = "proxy-test"
+   launch-template-id = "proxy-test"
    elb-security-group-names = [
      "elb-security-group-test",
      "elb-security-group-test2"

--- a/core/src/test/resources/nelson/datacenters-missing-subnet.cfg
+++ b/core/src/test/resources/nelson/datacenters-missing-subnet.cfg
@@ -18,7 +18,7 @@ aws {
   access-key-id = "key"
   secret-access-key = "secret"
   region = "texas"
-  launch-configuration-name = "proxy-test"
+  launch-template-id = "proxy-test"
   elb-security-group-names = [ "elb-security-group-test", "elb-security-group-test2" ]
   availability-zones {
     texas-a {

--- a/core/src/test/resources/nelson/datacenters-valid-aws.cfg
+++ b/core/src/test/resources/nelson/datacenters-valid-aws.cfg
@@ -16,7 +16,7 @@
 ##: ----------------------------------------------------------------------------
 aws {
   region = "us-west-2"
-  launch-configuration-name = "sdfsdfdsf"
+  launch-template-id = "sdfsdfdsf"
   elb-security-group-names = [ "sg-123", "sg-456" ]
   use-internal-elb = true
   availability-zones {

--- a/core/src/test/resources/nelson/datacenters.cfg
+++ b/core/src/test/resources/nelson/datacenters.cfg
@@ -93,7 +93,7 @@ nelson {
             access-key-id = "key"
             secret-access-key = "secret"
             region = "us-west-2"
-            launch-configuration-name = "proxy-test"
+            launch-template-id = "proxy-test"
             elb-security-group-names = [
               "elb-security-group-test",
               "elb-security-group-test2"

--- a/docs/src/hugo/content/documentation/configuration.md
+++ b/docs/src/hugo/content/documentation/configuration.md
@@ -566,7 +566,7 @@ In order to enable Nelson's support for dynamically provisioning load-balencers 
 * [loadbalancer.aws.availability-zones](#loadbalancer-aws-image)
 * [loadbalancer.aws.elb-security-group-names](#loadbalancer-aws-image)
 * [loadbalancer.aws.image](#loadbalancer-aws-image)
-* [loadbalancer.aws.launch-configuration-name](#loadbalancer-aws-launch-configuration-name)
+* [loadbalancer.aws.launch-template-id](#loadbalancer-aws-launch-template-id)
 * [loadbalancer.aws.region](#loadbalancer-aws-region)
 * [loadbalancer.aws.secret-access-key](#loadbalancer-aws-secret-access-key)
 * [loadbalancer.aws.use-internal-elb](#loadbalancer-use-internal-elb)
@@ -613,12 +613,12 @@ Some operators prefer to run the proxy software as a container that is dynamical
 datacenter.texas.infrastructure.loadbalancer.aws.image = "registry.texas.corp/whatever/infra-lb:1.2.3"
 ```
 
-#### loadbalancer.aws.launch-configuration-name
+#### loadbalancer.aws.launch-template-id
 
-Nelson will use the specified launch configuration to launch the resources. How this launch configuration is specified - perhaps CloudFormation or Terraform - is out of scope for this documentation, as Nelson only needs to know the name of the launch configuration to boot as a "black box".
+Nelson will use the specified launch template ID to launch the resources. How this launch template is specified - perhaps CloudFormation or Terraform - is out of scope for this documentation, as Nelson only needs to know the unique ID of the launch template to boot as a "black box". The launch template used will be whatever is marked as `Default` in the AWS settings for the launch template. This affords the user the ability to incrementally make changes, to the launch template without affecting active deployments without explicitly intending to do so.
 
 ```
-datacenter.texas.infrastructure.loadbalancer.aws.launch-configuration-name = "yourlb-XXXXXXXXXXXX"
+datacenter.texas.infrastructure.loadbalancer.aws.launch-template-id = "lt-XXXXXXXXXXXX"
 ```
 
 #### loadbalancer.aws.region

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
 //:   limitations under the License.
 //:
 //: ----------------------------------------------------------------------------
-version in ThisBuild := "0.13.0-SNAPSHOT"
+version in ThisBuild := "0.14.0-SNAPSHOT"


### PR DESCRIPTION
This change is needed to bring Nelson into the recent world. This change prevents having to redeploy Nelson when updating ingress clusters, and instead relies on the fact that launch templates are in fact pointers to a particular revision of launch config (under the hood). In this way, Nelson gets a "static" launch template definition, whilst out-of-band people can manage their launch templates with Terraform / Cloud formation (or bash scripts, you animals), and then manage the upgrades to the ingress cluster machines.