### PR TITLE
Create PKI roles so services can create certificates

### DIFF
--- a/core/src/main/scala/InstrumentedVaultClient.scala
+++ b/core/src/main/scala/InstrumentedVaultClient.scala
@@ -54,6 +54,8 @@ class InstrumentedVaultClient private (instance: String, interp: Vault ~> IO, me
     case _: CreateToken => "createToken"
     case _: CreateKubernetesRole => "createKubernetesRole"
     case _: DeleteKubernetesRole => "deleteKubernetesRole"
+    case _: CreatePKIRole => "createPKIRole"
+    case _: DeletePKIRole => "deletePKIRole"
   }
 }
 

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -160,6 +160,22 @@ object Workflow {
         roleName = sn.toString
       ).inject
 
+    def writePKIRoleToVault(dc: Datacenter, sn: StackName): WorkflowF[Unit] =
+      Vault.createPKIRole(
+        engineName = dc.name,
+        roleName = sn.toString,
+        serviceAccountNames = List(sn.toString),
+        defaultLeaseTTL = None,
+        maxLeaseTTL = None,
+        allowLocalhost = false
+      ).inject
+
+    def deletePKIRoleFromVault(dc: Datacenter, sn: StackName): WorkflowF[Unit] =
+      Vault.deletePKIRole(
+        engineName = dc.name,
+        roleName = sn.toString
+      ).inject
+
     def writeDiscoveryToConsul(id: ID, sn: StackName, ns: NamespaceName, dc: Datacenter): WorkflowF[Unit] =
       for {
         d  <- StoreOp.getDeployment(id).inject[WorkflowOp]

--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -61,6 +61,8 @@ final class Http4sVaultClient(
     case ct: CreateToken          => createToken(ct)
     case kr: CreateKubernetesRole => createKubernetesRole(kr)
     case dr: DeleteKubernetesRole => deleteKubernetesRole(dr)
+    case cpkir: CreatePKIRole     => createPKIRole(cpkir)
+    case dpkir: DeletePKIRole     => deletePKIRole(dpkir)
   }
 
   val log = Logger[this.type]
@@ -150,4 +152,14 @@ final class Http4sVaultClient(
 
   private def kubernetesAuthEngineName(cn: String): String =
     authBackendPrefix.map(_ + cn).getOrElse(cn)
+
+  def createPKIRole(cpkir: CreatePKIRole): IO[Unit] = {
+    val engine = kubernetesAuthEngineName(cpkir.engineName)
+    reqVoid(IO.pure(Request(POST, v1BaseUri / engine / "roles" / cpkir.roleName)))
+  }
+
+  def deletePKIRole(dpkir: DeletePKIRole): IO[Unit] = {
+    val engine = kubernetesAuthEngineName(cpkir.engineName)
+    reqVoid(IO.pure(Request(DELETE, v1BaseUri / engine / "roles" / cpkir.roleName)))
+  }
 }

--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -159,7 +159,7 @@ final class Http4sVaultClient(
   }
 
   def deletePKIRole(dpkir: DeletePKIRole): IO[Unit] = {
-    val engine = kubernetesAuthEngineName(cpkir.engineName)
-    reqVoid(IO.pure(Request(DELETE, v1BaseUri / engine / "roles" / cpkir.roleName)))
+    val engine = kubernetesAuthEngineName(dpkir.engineName)
+    reqVoid(IO.pure(Request(DELETE, v1BaseUri / engine / "roles" / dpkir.roleName)))
   }
 }

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -114,4 +114,13 @@ trait Json {
       ("policies" :?= kr.policies) ->?:
       jEmptyObject
     }
+
+    implicit val jsonCreatePKIRole: EncodeJson[CreatePKIRole] =
+    EncodeJson { cpkir =>
+      ("name" := cpkir.serviceAccountNames) ->:
+      ("ttl" :?= cpkir.defaultLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
+      ("max_ttl" :?= cpkir.maxLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
+      ("allow_localhost" :?= cpkir.allowLocalhost) ->?:
+      jEmptyObject
+    }
 }

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -115,12 +115,12 @@ trait Json {
       jEmptyObject
     }
 
-    implicit val jsonCreatePKIRole: EncodeJson[CreatePKIRole] =
+  implicit val jsonCreatePKIRole: EncodeJson[CreatePKIRole] =
     EncodeJson { cpkir =>
       ("name" := cpkir.serviceAccountNames) ->:
       ("ttl" :?= cpkir.defaultLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
       ("max_ttl" :?= cpkir.maxLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
-      ("allow_localhost" :?= cpkir.allowLocalhost) ->?:
+      ("allow_localhost" := cpkir.allowLocalhost) ->:
       jEmptyObject
     }
 }

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -130,6 +130,15 @@ object Vault {
     roleName: String
   ): VaultF[Unit] = Free.liftF(DeleteKubernetesRole(authClusterName, roleName))
 
+  // TODO(drewgonzales360): Do some sort of validation to ensure the roleName is a unitName
+  def createPKIRole(
+    roleName: String
+  ): VaultF[Unit] = Free.liftF(createPKIRole(roleName))
+
+  def deletePKIRole(
+    roleName: String
+  ): VaultF[Unit] = Free.liftF(deletePKIRole(roleName))
+
   case object IsInitialized extends Vault[Boolean]
   final case class Initialize(init: Initialization) extends Vault[InitialCreds]
   final case class Unseal(key: MasterKey) extends Vault[SealStatus]
@@ -151,4 +160,3 @@ object Vault {
     policies: Option[List[String]]) extends Vault[Unit]
   final case class DeleteKubernetesRole(authClusterName: String, roleName: String) extends Vault[Unit]
 }
-

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -130,14 +130,23 @@ object Vault {
     roleName: String
   ): VaultF[Unit] = Free.liftF(DeleteKubernetesRole(authClusterName, roleName))
 
-  // TODO(drewgonzales360): Do some sort of validation to ensure the roleName is a unitName
   def createPKIRole(
-    roleName: String
-  ): VaultF[Unit] = Free.liftF(createPKIRole(roleName))
+    engineName: String,
+    roleName: String,
+    serviceAccountNames: List[String],
+    defaultLeaseTTL: Option[FiniteDuration],
+    maxLeaseTTL: Option[FiniteDuration],
+    allowLocalhost: Boolean
+  ): VaultF[Unit] = Free.liftF(CreatePKIRole(
+    engineName, roleName,
+    serviceAccountNames,
+    defaultLeaseTTL, maxLeaseTTL,
+    allowLocalhost))
 
   def deletePKIRole(
+    engineName: String,
     roleName: String
-  ): VaultF[Unit] = Free.liftF(deletePKIRole(roleName))
+  ): VaultF[Unit] = Free.liftF(DeletePKIRole(engineName, roleName))
 
   case object IsInitialized extends Vault[Boolean]
   final case class Initialize(init: Initialization) extends Vault[InitialCreds]
@@ -159,4 +168,13 @@ object Vault {
     maxLeaseTTL: Option[FiniteDuration],
     policies: Option[List[String]]) extends Vault[Unit]
   final case class DeleteKubernetesRole(authClusterName: String, roleName: String) extends Vault[Unit]
+  final case class CreatePKIRole(
+    engineName: String,
+    roleName: String,
+    serviceAccountNames: List[String],
+    defaultLeaseTTL: Option[FiniteDuration],
+    maxLeaseTTL: Option[FiniteDuration],
+    allowLocalhost: Boolean
+  ) extends Vault[Unit]
+  final case class DeletePKIRole(engineName: String, roleName: String) extends Vault[Unit]
 }

--- a/core/src/main/scala/workflows/Pulsar.scala
+++ b/core/src/main/scala/workflows/Pulsar.scala
@@ -54,6 +54,9 @@ object Pulsar extends Workflow[Unit] {
       //// create a Vault kubernetes auth role
       _  <- logToFile(id, s"Writing Kubernetes auth role '${sn.toString}' to Vault...")
       _  <- writeKubernetesRoleToVault(dc = dc, sn = sn, ns = ns.name)
+      //// create a Vault PKI auth role
+      _  <- logToFile(id, s"Writing PKI auth role '${sn.toString}' to Vault...")
+      _  <- writePKIRoleToVault(dc = dc, sn = sn)
       //// write the needful to consul
       _  <- logToFile(id, s"writing discovery tables to ${routing.Discovery.consulDiscoveryKey(sn)}")
       _  <- writeDiscoveryToConsul(id, sn, ns.name, dc)
@@ -72,6 +75,8 @@ object Pulsar extends Workflow[Unit] {
     deletePolicyFromVault(d.stackName, ns.name) *>
     logToFile(d.id, s"removing kubernetes role from vault: ${vaultLoggingFields(stackName, ns = ns.name, dcName = dc.name)}") *>
     deleteKubernetesRoleFromVault(dc, d.stackName) *>
+    logToFile(d.id, s"removing PKI role from vault: ${vaultLoggingFields(stackName, ns = ns.name, dcName = dc.name)}") *>
+    deletePKIRoleFromVault(dc, d.stackName) *>
     logToFile(d.id, s"instructing ${dc.name}'s scheduler to decomission ${stackName}") *>
     delete(dc, d) *>
     status(d.id, Terminated, s"Decomissioning deployment ${stackName} in ${dc.name}")

--- a/core/src/test/scala/NelsonSuite.scala
+++ b/core/src/test/scala/NelsonSuite.scala
@@ -104,6 +104,8 @@ trait NelsonSuite
       case _: Vault.CreateToken => vault.Token("aaaaaaaa-bbbb-cccc-dddddddddddd")
       case _: Vault.CreateKubernetesRole => ()
       case _: Vault.DeleteKubernetesRole => ()
+      case _: Vault.CreatePKIRole => ()
+      case _: Vault.DeletePKIRole => ()
     })
   }
 


### PR DESCRIPTION
Branching off of #233:

"In Vault, the PKI engine requires that a role be created so that certificates can be issued against it. When certs are issued, services that take ingress traffic can TLS secured.
 
This PR adds functionality to create these roles."