### PR TITLE
Fix PKI path for role creation

### DIFF
--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -162,6 +162,7 @@ object Workflow {
 
     def writePKIRoleToVault(dc: Datacenter, sn: StackName): WorkflowF[Unit] =
       Vault.createPKIRole(
+        pkiPath = dc.policy.pkiPath,
         engineName = dc.name,
         roleName = sn.toString,
         serviceAccountNames = List(sn.toString),
@@ -172,6 +173,7 @@ object Workflow {
 
     def deletePKIRoleFromVault(dc: Datacenter, sn: StackName): WorkflowF[Unit] =
       Vault.deletePKIRole(
+        pkiPath = dc.policy.pkiPath,
         engineName = dc.name,
         roleName = sn.toString
       ).inject

--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -154,12 +154,12 @@ final class Http4sVaultClient(
     authBackendPrefix.map(_ + cn).getOrElse(cn)
 
   def createPKIRole(cpkir: CreatePKIRole): IO[Unit] = {
-    val engine = kubernetesAuthEngineName(cpkir.engineName)
-    reqVoid(IO.pure(Request(POST, v1BaseUri / engine / "roles" / cpkir.roleName)))
+    val pkiPath = cpkir.pkiPath.getOrElse("pki")
+    reqVoid(IO.pure(Request(POST, v1BaseUri / pkiPath / "roles" / cpkir.roleName)))
   }
 
   def deletePKIRole(dpkir: DeletePKIRole): IO[Unit] = {
-    val engine = kubernetesAuthEngineName(dpkir.engineName)
-    reqVoid(IO.pure(Request(DELETE, v1BaseUri / engine / "roles" / dpkir.roleName)))
+    val pkiPath = dpkir.pkiPath.getOrElse("pki")
+    reqVoid(IO.pure(Request(DELETE, v1BaseUri / pkiPath / "roles" / dpkir.roleName)))
   }
 }

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -131,6 +131,7 @@ object Vault {
   ): VaultF[Unit] = Free.liftF(DeleteKubernetesRole(authClusterName, roleName))
 
   def createPKIRole(
+    pkiPath: Option[String],
     engineName: String,
     roleName: String,
     serviceAccountNames: List[String],
@@ -138,15 +139,17 @@ object Vault {
     maxLeaseTTL: Option[FiniteDuration],
     allowLocalhost: Boolean
   ): VaultF[Unit] = Free.liftF(CreatePKIRole(
+    pkiPath,
     engineName, roleName,
     serviceAccountNames,
     defaultLeaseTTL, maxLeaseTTL,
     allowLocalhost))
 
   def deletePKIRole(
+    pkiPath: Option[String],
     engineName: String,
     roleName: String
-  ): VaultF[Unit] = Free.liftF(DeletePKIRole(engineName, roleName))
+  ): VaultF[Unit] = Free.liftF(DeletePKIRole(pkiPath, engineName, roleName))
 
   case object IsInitialized extends Vault[Boolean]
   final case class Initialize(init: Initialization) extends Vault[InitialCreds]
@@ -169,6 +172,7 @@ object Vault {
     policies: Option[List[String]]) extends Vault[Unit]
   final case class DeleteKubernetesRole(authClusterName: String, roleName: String) extends Vault[Unit]
   final case class CreatePKIRole(
+    pkiPath: Option[String],
     engineName: String,
     roleName: String,
     serviceAccountNames: List[String],
@@ -176,5 +180,9 @@ object Vault {
     maxLeaseTTL: Option[FiniteDuration],
     allowLocalhost: Boolean
   ) extends Vault[Unit]
-  final case class DeletePKIRole(engineName: String, roleName: String) extends Vault[Unit]
+  final case class DeletePKIRole(
+    pkiPath: Option[String], 
+    engineName: String, 
+    roleName: String
+  ) extends Vault[Unit]
 }


### PR DESCRIPTION
PKI path from change #242 incorrectly specifies the Vault path for PKI role creation; this change fixes that path, and assumes a default path of `pki` otherwise (Vault default). 

If the user is configuring a custom path, it should be specified in the Nelson configuration under:
```
datacenters {
    <datacenter> {
       ...

      policy {
        ...

        # Path to your PKI backend. Optional. If specified, unit will get
        # create and update capabilities on ${pki-path}/issue
        pki-path = "pki/my-path/dev"
      }
    }
  }
```

and _not_ under the `infrastructure { vault { ... } }` subconfiguration.