### PR TITLE
AWS DC: Try to remove ELB if NLB doesn't exist

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -49,6 +49,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons"          % "commons-email"                        % "1.3.3",
   "commons-codec"               % "commons-codec"                        % "1.11",
   "com.amazonaws"               % "aws-java-sdk-autoscaling"             % "1.11.595",
+  "com.amazonaws"               % "aws-java-sdk-elasticloadbalancing"    % "1.11.595",
   "com.amazonaws"               % "aws-java-sdk-elasticloadbalancingv2"  % "1.11.595",
   "com.google.guava"            % "guava"                                % "20.0",
   "com.google.code.findbugs"    % "jsr305"                               % "3.0.1", // needed to provide class javax.annotation.Nullable

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -116,7 +116,7 @@ object Infrastructure {
     image: Option[String],
     lbScheme: loadbalancers.NlbScheme
   ) {
-    import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder
+
     import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder
 
     val asg = AmazonAutoScalingClientBuilder
@@ -125,7 +125,13 @@ object Infrastructure {
       .withRegion(region.getName)
       .build()
 
-    val nlb = AmazonElasticLoadBalancingClientBuilder
+    val elb = com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder
+      .standard
+      .withCredentials(creds)
+      .withRegion(region.getName)
+      .build()
+
+    val nlb = com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder
       .standard
       .withCredentials(creds)
       .withRegion(region.getName)

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -31,7 +31,7 @@ import cats.implicits._
 
 import helm.ConsulOp
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 /**
  * Workflows must be defined in terms of a particular type of UnitDef
@@ -172,9 +172,11 @@ object Workflow {
         roleName = sn.toString,
         serviceAccountNames = List(sn.toString),
         defaultLeaseTTL = None,
-        maxLeaseTTL = None,
+        maxLeaseTTL = Some(43800.hours) /* 5 years */,
         allowLocalhost = false,
-        pkiPath = interpolatedPkiPath
+        requireCN = false,
+        pkiPath = interpolatedPkiPath,
+        allowAnyName = true
       ).inject
     }
 

--- a/core/src/main/scala/loadbalancers/Aws.scala
+++ b/core/src/main/scala/loadbalancers/Aws.scala
@@ -79,7 +79,7 @@ final class Aws(cfg: Infrastructure.Aws) extends (LoadbalancerOp ~> IO) {
 
   def launch(lb: Manifest.Loadbalancer, v: MajorVersion, ns: NamespaceName, p: Plan, hash: String): IO[DNSName] = {
     val name = loadbalancerName(lb.name, v, hash)
-    val tgPrefix = targetGroupNamePrefix(lb.name, v)
+    val tgPrefix = targetGroupNamePrefix(lb.name, hash)
     val size = asgSize(p)
 
     for {
@@ -97,13 +97,14 @@ final class Aws(cfg: Infrastructure.Aws) extends (LoadbalancerOp ~> IO) {
   // The target groups have a restriction such that name of the target group can't
   // have "double dashes" and the entire name must be less than 32 characters.
   // Unfortunately, target groups will not have the same name as the loadbalancers.
-  // An example target group will be named stack-1-0-0-443 where the last number is the
-  // port that it listens on (instead of the hash). This allows stack-1-0-0-80 to be
+  // An example target group will be named stack-aevaif-443 where the last number is the
+  // port that it listens on (instead of the hash). This allows stack-qweri-80 to be
   // a different target group for the same loadbalancer. Since target groups are only
   // associated with a single loadbalancer at a time, it'll be easy to reason about which target
-  // groups are related to which loadbalancers.
-  def targetGroupNamePrefix(name: String, v: MajorVersion) =
-    s"$name-${v.minVersion.toExternalString}"
+  // groups are related to which loadbalancers. Administrators will need to reason about
+  // which target group belongs to which loadbalancer based on the hash in the target group name.
+  def targetGroupNamePrefix(name: String, hash: String) =
+    s"$name-$hash"
 
   def getLoadBalancerArn(name: String): IO[String] = {
     val describeLoadBalancerRequest = new DescribeLoadBalancersRequest().withNames(name)

--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -154,7 +154,7 @@ final class Http4sVaultClient(
     authBackendPrefix.map(_ + cn).getOrElse(cn)
 
   def createPKIRole(cpkir: CreatePKIRole): IO[Unit] = {
-    reqVoid(IO.pure(Request(POST, v1BaseUri / cpkir.pkiPath / "roles" / cpkir.roleName)))
+    reqVoid(Request(POST, v1BaseUri / cpkir.pkiPath / "roles" / cpkir.roleName).withBody(cpkir.asJson))
   }
 
   def deletePKIRole(dpkir: DeletePKIRole): IO[Unit] = {

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -121,6 +121,8 @@ trait Json {
       ("ttl" :?= cpkir.defaultLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
       ("max_ttl" :?= cpkir.maxLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
       ("allow_localhost" := cpkir.allowLocalhost) ->:
+      ("require_cn" := cpkir.requireCN) ->:
+      ("allow_any_name" := cpkir.allowAnyName) ->:
       jEmptyObject
     }
 }

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -137,13 +137,17 @@ object Vault {
     defaultLeaseTTL: Option[FiniteDuration],
     maxLeaseTTL: Option[FiniteDuration],
     allowLocalhost: Boolean,
-    pkiPath: String
+    requireCN: Boolean,
+    pkiPath: String,
+    allowAnyName: Boolean
   ): VaultF[Unit] = Free.liftF(CreatePKIRole(
     engineName, roleName,
     serviceAccountNames,
     defaultLeaseTTL, maxLeaseTTL,
     allowLocalhost,
-    pkiPath))
+    requireCN,
+    pkiPath,
+    allowAnyName))
 
   def deletePKIRole(
     engineName: String,
@@ -178,10 +182,12 @@ object Vault {
     defaultLeaseTTL: Option[FiniteDuration],
     maxLeaseTTL: Option[FiniteDuration],
     allowLocalhost: Boolean,
-    pkiPath: String
+    requireCN: Boolean,
+    pkiPath: String,
+    allowAnyName: Boolean
   ) extends Vault[Unit]
   final case class DeletePKIRole(
-    engineName: String, 
+    engineName: String,
     roleName: String,
     pkiPath: String
   ) extends Vault[Unit]


### PR DESCRIPTION
# Summary

If Nelson loadbalancers were provisioned with an older version of Nelson, classic AWS loadbalancers were created. This PR makes deleting those loadbalancers possible with the newer versions of Nelson IE 0.15.x

# Tested
I hopped into the repl with a few scripts and checked out a commit of Nelson that created classic loadbalancers. I created a classic loadbalancer from Nelson.

Then I checked out the head of this branch which uses NLB's. I called loadbalancers.delete and watched Nelson fail to delete the NLB, then try to delete the ELB and succeed. 

```
01:15:12.394 [run-main-1] ERROR nelson.loadbalancers.Aws - aws call to get loadbalancer ARN classic--1-0-0--hashhash failed.
01:15:12.395 [run-main-1] INFO  nelson.loadbalancers.Aws - couldn't delete NLB because Loadbalancer deployment (could not find loadbalancer and therefore could not delete loadbalancer) failed because Load balancers '[classic--1-0-0--hashhash]' not found (Service: AmazonElasticLoadBalancing; Status Code: 400; Error Code: LoadBalancerNotFound; Request ID: adsfsadfasdf-asdfasdf-asdfasdfsadf). attempting to delete ELB
```

I also tested creating and deleting NLB's

## Our Current Use Case
We used to use a version of Nelson that provisioned classic loadbalancers. To use the "Network Loadbalancers", we upgraded the java sdk to use the loadbalancingv2 package. This package can't delete "classic loadbalancers" ie it is not backwards compatible. 