### PR TITLE
updates to vault api

### DIFF
--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -31,7 +31,7 @@ import cats.implicits._
 
 import helm.ConsulOp
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 /**
  * Workflows must be defined in terms of a particular type of UnitDef
@@ -172,9 +172,11 @@ object Workflow {
         roleName = sn.toString,
         serviceAccountNames = List(sn.toString),
         defaultLeaseTTL = None,
-        maxLeaseTTL = None,
+        maxLeaseTTL = Some(43800.hours) /* 5 years */,
         allowLocalhost = false,
-        pkiPath = interpolatedPkiPath
+        requireCN = false,
+        pkiPath = interpolatedPkiPath,
+        allowAnyName = true
       ).inject
     }
 

--- a/core/src/main/scala/vault/http/Http4sVault.scala
+++ b/core/src/main/scala/vault/http/Http4sVault.scala
@@ -154,7 +154,7 @@ final class Http4sVaultClient(
     authBackendPrefix.map(_ + cn).getOrElse(cn)
 
   def createPKIRole(cpkir: CreatePKIRole): IO[Unit] = {
-    reqVoid(IO.pure(Request(POST, v1BaseUri / cpkir.pkiPath / "roles" / cpkir.roleName)))
+    reqVoid(Request(POST, v1BaseUri / cpkir.pkiPath / "roles" / cpkir.roleName).withBody(cpkir.asJson))
   }
 
   def deletePKIRole(dpkir: DeletePKIRole): IO[Unit] = {

--- a/core/src/main/scala/vault/http/json.scala
+++ b/core/src/main/scala/vault/http/json.scala
@@ -121,6 +121,8 @@ trait Json {
       ("ttl" :?= cpkir.defaultLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
       ("max_ttl" :?= cpkir.maxLeaseTTL.map(d => s"${d.toMillis}ms")) ->?:
       ("allow_localhost" := cpkir.allowLocalhost) ->:
+      ("require_cn" := cpkir.requireCN) ->:
+      ("allow_any_name" := cpkir.allowAnyName) ->:
       jEmptyObject
     }
 }

--- a/core/src/main/scala/vault/op.scala
+++ b/core/src/main/scala/vault/op.scala
@@ -137,13 +137,17 @@ object Vault {
     defaultLeaseTTL: Option[FiniteDuration],
     maxLeaseTTL: Option[FiniteDuration],
     allowLocalhost: Boolean,
-    pkiPath: String
+    requireCN: Boolean,
+    pkiPath: String,
+    allowAnyName: Boolean
   ): VaultF[Unit] = Free.liftF(CreatePKIRole(
     engineName, roleName,
     serviceAccountNames,
     defaultLeaseTTL, maxLeaseTTL,
     allowLocalhost,
-    pkiPath))
+    requireCN,
+    pkiPath,
+    allowAnyName))
 
   def deletePKIRole(
     engineName: String,
@@ -178,10 +182,12 @@ object Vault {
     defaultLeaseTTL: Option[FiniteDuration],
     maxLeaseTTL: Option[FiniteDuration],
     allowLocalhost: Boolean,
-    pkiPath: String
+    requireCN: Boolean,
+    pkiPath: String,
+    allowAnyName: Boolean
   ) extends Vault[Unit]
   final case class DeletePKIRole(
-    engineName: String, 
+    engineName: String,
     roleName: String,
     pkiPath: String
   ) extends Vault[Unit]


### PR DESCRIPTION
# Summary
- bugfix: When Nelson attempted to create a vault role in the PKI engine, the json body wasn't being passed. When you make a request without a body, the Vault API will assume all the defaults. 
- modified the Vault API defaults a bit to rely on the trust chain instead of the domain. We don't force users to put a domain by default and allow any CName to get put on the certificate. 