### PR TITLE
Delete Classic Loadbalancer if it is present

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -49,6 +49,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons"          % "commons-email"                        % "1.3.3",
   "commons-codec"               % "commons-codec"                        % "1.11",
   "com.amazonaws"               % "aws-java-sdk-autoscaling"             % "1.11.595",
+  "com.amazonaws"               % "aws-java-sdk-elasticloadbalancing"    % "1.11.595",
   "com.amazonaws"               % "aws-java-sdk-elasticloadbalancingv2"  % "1.11.595",
   "com.google.guava"            % "guava"                                % "20.0",
   "com.google.code.findbugs"    % "jsr305"                               % "3.0.1", // needed to provide class javax.annotation.Nullable

--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -116,7 +116,7 @@ object Infrastructure {
     image: Option[String],
     lbScheme: loadbalancers.NlbScheme
   ) {
-    import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder
+
     import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder
 
     val asg = AmazonAutoScalingClientBuilder
@@ -125,7 +125,13 @@ object Infrastructure {
       .withRegion(region.getName)
       .build()
 
-    val nlb = AmazonElasticLoadBalancingClientBuilder
+    val elb = com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder
+      .standard
+      .withCredentials(creds)
+      .withRegion(region.getName)
+      .build()
+
+    val nlb = com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder
       .standard
       .withCredentials(creds)
       .withRegion(region.getName)


### PR DESCRIPTION
# Summary
When the changes to use the Network Loadbalancer were made, I changed that whole subsystem to assume _only_ AWS network loadbalancers were used. In reality, our deployment of Nelson previously used AWS Classic Loadbalancers.

If an org used Classic Loadbalancers in the past, then we should attempt to delete the classic loadbalancer when deleting the Network loadbalancer fails. 