### PR TITLE
Move blueprint rendering into the workflow

### DIFF
--- a/core/src/main/scala/Config.scala
+++ b/core/src/main/scala/Config.scala
@@ -605,7 +605,7 @@ object Config {
       val scheduling: IO[SchedulerOp ~> IO] = kfg.lookup[String]("infrastructure.scheduler") match {
         case Some("kubernetes") => {
           withKubectl((kubectl, timeout) =>
-            IO.pure(new KubernetesShell(kubectl, timeout, ec)))
+            IO.pure(new KubernetesShell(kubectl, timeout, schedulerPool,  ec)))
         }
         case Some("nomad") => IO.raiseError(NomadNotImplemented)
         case _ => IO.raiseError(new IllegalArgumentException("At least one scheduler must be defined per datacenter"))

--- a/core/src/main/scala/Workflow.scala
+++ b/core/src/main/scala/Workflow.scala
@@ -128,9 +128,7 @@ object Workflow {
           val rendered = bp.template.render(env)
           StoreOp.updateDeploymentBlueprint(id, Option(rendered)).map(_ => rendered).inject
         case None =>
-          logToFile(id, "no blueprint specified, defaulting to using fallback...") *>
-          fail("Default blueprints are not supported by pulsar")
-          // pure(f(p).render(env))
+          fail("Nelson no longer supports deployment without a blueprint specified; please adjust your manifest and re-submit.")
       }
     }
 

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -56,6 +56,7 @@ package object nelson {
   type DNSName = String
   type DeploymentStatusString = String
   type Sha256 = String
+  type RenderedBlueprint = String
 
 /** Copied and adapted from Scalaz's Tag implementation.
   * https://github.com/scalaz/scalaz/blob/v7.1.17/core/src/main/scala/scalaz/package.scala

--- a/core/src/main/scala/scheduler/KubernetesShell.scala
+++ b/core/src/main/scala/scheduler/KubernetesShell.scala
@@ -3,9 +3,6 @@ package scheduler
 
 import nelson.Datacenter.{Deployment, StackName}
 import nelson.Kubectl.{DeploymentStatus, JobStatus, KubectlError}
-import nelson.Manifest.{HealthCheck => _, _}
-import nelson.blueprint.{DefaultBlueprints, Render}
-import nelson.docker.Docker.Image
 import nelson.scheduler.SchedulerOp._
 
 import nelson.CatsHelpers._
@@ -15,6 +12,7 @@ import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.ScheduledExecutorService
 
 /**
  * SchedulerOp interpreter that uses the Kubernetes API server.
@@ -24,6 +22,7 @@ import scala.concurrent.duration.FiniteDuration
 final class KubernetesShell(
   kubectl: Kubectl,
   timeout: FiniteDuration,
+  scheduler: ScheduledExecutorService,
   executionContext: ExecutionContext
 ) extends (SchedulerOp ~> IO) {
   import KubernetesShell._
@@ -32,11 +31,17 @@ final class KubernetesShell(
 
   def apply[A](fa: SchedulerOp[A]): IO[A] = fa match {
     case Delete(_, deployment) =>
-      delete(deployment).timed(timeout)
-    case Launch(image, dc, ns, unit, plan, hash) =>
-      launch(image, dc, ns, Versioned.unwrap(unit), unit.version, plan, hash).timed(timeout)
+      delete(deployment)
+        .retryExponentially(limit = 3)(scheduler, kubernetesShellExecutionContext)
+        .timed(timeout)
+    case Launch(_, _, _, _, _, _, bp) =>
+      kubectl.apply(bp)
+        .retryExponentially(limit = 3)(scheduler, kubernetesShellExecutionContext)
+        .timed(timeout)
     case Summary(_, ns, stackName) =>
-      summary(ns, stackName).timed(timeout)
+      summary(ns, stackName)
+        .retryExponentially(limit = 3)(scheduler, kubernetesShellExecutionContext)
+        .timed(timeout)
   }
 
   def delete(deployment: Deployment): IO[Unit] = {
@@ -61,33 +66,6 @@ final class KubernetesShell(
   // it was not found as opposed to some other reason like RBAC permissions
   private def notFound(error: KubectlError): Boolean =
     error.stderr.exists(_.startsWith("Error from server (NotFound)"))
-
-  def launch(image: Image, dc: Datacenter, ns: NamespaceName, unit: UnitDef, version: Version, plan: Plan, hash: String): IO[String] = {
-    val env = Render.makeEnv(image, dc, ns, unit, version, plan, hash)
-
-    val fallback = Manifest.getSchedule(plan) match {
-      case None => DefaultBlueprints.canopus.service
-      case Some(sched) => sched.toCron match {
-        case None => DefaultBlueprints.canopus.job
-        case Some(_) => DefaultBlueprints.canopus.cronJob
-      }
-    }
-
-    // NOTE: by this point in the system, we know we're dealing with
-    // a hydrated blueprint (i.e. passes manifest validation and exists
-    // in the database) so we simply take the supplied plan and extract
-    // the `Blueprint`, and `Template` in turn.
-    val template = plan.environment.blueprint match {
-      case Some(Left(_)) => IO.raiseError(new IllegalArgumentException(s"Internal error occured: un-hydrated blueprint passed to scheduler!"))
-      case Some(Right(bp)) => IO.pure(bp.template)
-      case None => fallback
-    }
-
-    for {
-      t <- template
-      r <- kubectl.apply(t.render(env))
-    } yield r
-  }
 
   def summary(ns: NamespaceName, stackName: StackName): IO[Option[DeploymentSummary]] =
     deploymentSummary(ns, stackName).recoverWith { case _ =>

--- a/core/src/main/scala/scheduler/NomadHttp.scala
+++ b/core/src/main/scala/scheduler/NomadHttp.scala
@@ -58,7 +58,7 @@ final class NomadHttp(
     co match {
       case Delete(dc,d) =>
         deleteUnitAndChildren(dc, d).retryExponentially()(scheduler, ec)
-      case Launch(i, dc, ns, u, p, hash) =>
+      case Launch(i, dc, ns, u, p, hash, _) =>
         val unit = Manifest.Versioned.unwrap(u)
         launch(unit, hash, u.version, i, dc, ns, p).retryExponentially()(scheduler, ec)
       case Summary(dc,_,sn) =>

--- a/core/src/main/scala/scheduler/SchedulerOp.scala
+++ b/core/src/main/scala/scheduler/SchedulerOp.scala
@@ -28,14 +28,14 @@ object SchedulerOp {
 
   final case class Delete(dc: Datacenter, d: Datacenter.Deployment) extends SchedulerOp[Unit]
 
-  final case class Launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String) extends SchedulerOp[String]
+  final case class Launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String, bp: RenderedBlueprint) extends SchedulerOp[String]
 
   final case class Summary(dc: Datacenter, ns: NamespaceName, sn: Datacenter.StackName) extends SchedulerOp[Option[DeploymentSummary]]
 
   type SchedulerF[A] = Free[SchedulerOp, A]
 
-  def launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String): SchedulerF[String] =
-    Free.liftF(Launch(i, dc, ns, a, p, hash))
+  def launch(i: Image, dc: Datacenter, ns: NamespaceName, a: UnitDef @@ Versioned, p: Plan, hash: String, bp: RenderedBlueprint): SchedulerF[String] =
+    Free.liftF(Launch(i, dc, ns, a, p, hash, bp))
 
   def delete(dc: Datacenter, d: Datacenter.Deployment): SchedulerF[Unit] =
     Free.liftF(Delete(dc,d))

--- a/core/src/main/scala/storage/h2.scala
+++ b/core/src/main/scala/storage/h2.scala
@@ -321,8 +321,8 @@ final case class H2Storage(xa: Transactor[IO]) extends (StoreOp ~> IO) {
    *
    */
   def createDeploymentStatus(id: ID,
-                              status: DeploymentStatus,
-                              msg: Option[String]): ConnectionIO[Unit] =
+                             status: DeploymentStatus,
+                             msg: Option[String]): ConnectionIO[Unit] =
     sql"""
        INSERT INTO PUBLIC.deployment_statuses
               (deployment_id, state, status_msg, status_time)

--- a/core/src/main/scala/storage/op.scala
+++ b/core/src/main/scala/storage/op.scala
@@ -139,6 +139,9 @@ object StoreOp {
   def createDeploymentStatus(id: ID, status: DeploymentStatus, msg: Option[String]): StoreOpF[Unit] =
     Free.liftF(CreateDeploymentStatus(id, status, msg))
 
+  def updateDeploymentBlueprint(id: ID, bp: Option[RenderedBlueprint]): StoreOpF[Unit] =
+    Free.liftF(UpdateDeploymentBlueprint(id, bp))
+
   def listUnitsByStatus(nsid: ID, statuses: NonEmptyList[DeploymentStatus]): StoreOpF[Vector[(GUID,ServiceName)]] =
     Free.liftF(ListUnitsByStatus(nsid, statuses))
 
@@ -281,6 +284,7 @@ object StoreOp {
   final case class CreateDeployment(unitId: ID, hash: String, nn: Datacenter.Namespace, wf: WorkflowRef, plan: PlanRef, policy: ExpirationPolicyRef) extends StoreOp[ID]
   final case class GetDeploymentByGuid(guid: GUID) extends StoreOp[Option[Deployment]]
   final case class CreateDeploymentStatus(id: ID, status: DeploymentStatus, msg: Option[String]) extends StoreOp[Unit]
+  final case class UpdateDeploymentBlueprint(id: ID, bp: Option[RenderedBlueprint]) extends StoreOp[Unit]
   final case class ListUnitsByStatus(nsid: ID, statuses: NonEmptyList[DeploymentStatus]) extends StoreOp[Vector[(GUID,ServiceName)]]
   final case class CreateManualDeployment(datacenter: Datacenter, namespace: NamespaceName, serviceType: String, version: String, hash: String, description: String, port: Int, ext: Instant) extends StoreOp[GUID]
   final case class FindReleaseByDeploymentGuid(guid: GUID) extends StoreOp[Option[(Released, ReleasedDeployment)]]

--- a/core/src/test/scala/NelsonSuite.scala
+++ b/core/src/test/scala/NelsonSuite.scala
@@ -143,7 +143,7 @@ trait NelsonSuite
   lazy val sched = new (SchedulerOp ~> IO) {
     import scheduler.SchedulerOp._
     def apply[A](op: SchedulerOp[A]) = op match {
-      case Launch(_,_,_,unit,_,hash) =>
+      case Launch(_,_,_,unit,_,hash,_) =>
         val name = Manifest.Versioned.unwrap(unit).name
         val sn = Datacenter.StackName(name, unit.version,hash)
         IO(sn.toString)

--- a/etc/development/http/http.dev.cfg
+++ b/etc/development/http/http.dev.cfg
@@ -26,8 +26,8 @@ nelson {
     # only works where you have direct line of sight to the github enterprise.
     # would not work for github.com unless you're exposing your WAN IP publically.
     # export CURRENT_IP=`ifconfig en4 | grep inet | grep -v inet6 | awk '{print $2}'`
-    external-host = "nelson.local"
-    external-port = 9000
+    external-host = "$(NELSON_EXTERNAL_HOST)"
+    external-port = 443
     enable-tls = false
   }
 
@@ -55,16 +55,25 @@ nelson {
   github {
     # uncomment if you want to use a custom github enterprise domain
     # domain = "$(NELSON_GITHUB_DOMAIN)"
-    client-id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    client-secret = "xxxxxxxxxxxxxxxxxxxx"
-    redirect-uri = "http://nelson.local:9000/auth/exchange"
+    client-id = "$(NELSON_GITHUB_CLIENT)"
+    client-secret = "$(NELSON_GITHUB_SECRET)"
+    redirect-uri = "http://$(NELSON_EXTERNAL_HOST)/auth/exchange"
     organization-blacklist = []
+    access-token = "$(GITHUB_TOKEN)"
+    system-username = "$(GITHUB_USERNAME)"
   }
 
   database {
     driver     = "org.h2.Driver"
     # add this to the belown to get SQL tracing TRACE_LEVEL_FILE=4
     connection = "jdbc:h2:file:../db/dev;DATABASE_TO_UPPER=FALSE;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9090;"
+  }
+
+  cleanup {
+    initial-deployment-time-to-live = 3 minutes
+    extend-deployment-time-to-live = 2 minutes
+    cleanup-delay = 1 minutes
+    sweeper-delay = 24 hours
   }
 
   docker {

--- a/http/src/main/scala/Main.scala
+++ b/http/src/main/scala/Main.scala
@@ -77,7 +77,7 @@ object Main {
         log.info(s"starting the $name processor")
         Stoplight(s"${name}_stoplight")(p).compile.drain.unsafeRunAsync(_.fold(
           e => log.error(s"fatal error in background process: name=${name}", e),
-          _ => log.warn(s"background process completed unexpectedly without exception: name=${name}")
+          _ => log.error(s"background process completed unexpectedly without exception: name=${name}")
         ))
       }
 

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
 //:   limitations under the License.
 //:
 //: ----------------------------------------------------------------------------
-version in ThisBuild := "0.15.0-SNAPSHOT"
+version in ThisBuild := "0.16.0-SNAPSHOT"


### PR DESCRIPTION
Replace #254 

Implementing a fix for #252 - Presently untested DO NOT MERGE

This has semi-questionable semantics, but is significantly improved over the behavior in #254 as it allows the authors of workflows to more concisely control how their blueprints are rendered (you could even reach out to another system to retrieve your blueprint definition to fully externalize that logic from nelson). There are some nice side benefits to this:

1. if blueprint rendering fails, you get it in your logs.
2. if you're using the default blueprint, that is also in the output of `nelson stack logs`

