### PR TITLE
make the thread pool sizing configurable

### DIFF
--- a/core/src/main/resources/nelson/defaults.cfg
+++ b/core/src/main/resources/nelson/defaults.cfg
@@ -16,6 +16,20 @@
 ##: ----------------------------------------------------------------------------
 nelson {
 
+  pools {
+    # size of the fixed executor that is used for many of the
+    # async operations that happen internally with nelson.
+    # in most cases this default should be more than sufficient
+    # but as a general rule of thumb, you would want this value
+    # to be number of cpus * 2
+    default-size = 8
+
+    # number of threads available for the scheduling thread pool.
+    # this value should not be increased above 4 without understanding
+    # what the impact of the change would be.
+    scheduling-size = 4
+  }
+
   # generic default timeout for all http requests that
   # nelson is going to make to other systems (e.g. Github, Nomad)
   timeout = 4 seconds

--- a/docs/src/hugo/content/documentation/configuration.md
+++ b/docs/src/hugo/content/documentation/configuration.md
@@ -16,6 +16,7 @@ contents:
 - Github
 - Network
 - Pipeline
+- Pools
 - Security
 - Slack
 - Templating
@@ -912,6 +913,32 @@ Internally, the pipeline is implemented as a queue, and all queues buffer. To av
 
 ```
 nelson.pipeline.inbound-buffer-limit = 50
+```
+----
+
+## Pools
+
+<span class="badge badge-info">optional</span>
+
+In certain situations and deployments, its possible that users may want to configure the thread pools Nelson uses in order to reduce contention or improve performance via larger hardware. The size of the two configurable thread pools can be tuned using the following parameters:
+
+* [pools.default-size](#pools-default-size)
+* [pools.scheduling-size](#pools-scheduling-size)
+
+#### pools.default-size
+
+The default pool is the one that nearly all async operations within Nelson happen on, and in the event that Nelson is conducting a larger service operation, the default 8 threads might not be enough. Best practice is to configure this option as number of CPUs * 2.
+
+```
+nelson.pools.default-size = 8
+```
+
+#### pools.scheduling-size
+
+This pool is used for background operations being scheduled and typically should not be adjusted past its default value without advice from the Nelson engineering team.
+
+```
+nelson.pools.scheduling-size = 4
 ```
 
 ----


### PR DESCRIPTION
This adds the ability to specify `nelson.pools.default-size` and `nelson.pools.scheduling-size` in the nelson.cfg configuration file, adjusting the number of available threads to match the hardware that Nelson operates on, which is important for larger setups. 


```
    # size of the fixed executor that is used for many of the
    # async operations that happen internally with nelson.
    # in most cases this default should be more than sufficient
    # but as a general rule of thumb, you would want this value
    # to be number of cpus * 2
    default-size = 8

    # number of threads available for the scheduling thread pool.
    # this value should not be increased above 4 without understanding
    # what the impact of the change would be.
    scheduling-size = 4
```