### PR TITLE
Performance fix for large deployment tables when fetching status

### DIFF
--- a/core/src/main/scala/storage/h2.scala
+++ b/core/src/main/scala/storage/h2.scala
@@ -427,7 +427,7 @@ final case class H2Storage(xa: Transactor[IO]) extends (StoreOp ~> IO) {
         d.rendered_blueprint,
         ds.state
       FROM PUBLIC.deployments AS d
-      LEFT JOIN PUBLIC.deployment_statuses AS ds
+      INNER JOIN PUBLIC.deployment_statuses AS ds
         ON ds.deployment_id = d.id
         AND ds.id = (
           SELECT TOP 1 x.id
@@ -451,7 +451,7 @@ final case class H2Storage(xa: Transactor[IO]) extends (StoreOp ~> IO) {
         d.rendered_blueprint,
         ds.state
       FROM PUBLIC.deployments AS d
-      LEFT JOIN PUBLIC.deployment_statuses AS ds
+      INNER JOIN PUBLIC.deployment_statuses AS ds
         ON ds.deployment_id = d.id
         AND ds.id = (
           SELECT TOP 1 x.id


### PR DESCRIPTION
I'm debugging some performance issues in our environment whereby we have 15k records in the `deployments` table, and 95k in the `deployment_statuses` table.

When listing nelson stacks from the cli, the backend server is taking ~15-20s to respond. I isolated the issue to the [listDeploymentsForNamespaceByStatus](https://github.com/getnelson/nelson/blob/master/core/src/main/scala/storage/h2.scala#L412) function call, whereby the SQL query is taking about 15s to return server side (even running h2 locally it takes ~19s).

Looking at the explain plan for the query, h2 is doing multiple unnecessary scans of both tables, due to it using a `LEFT JOIN`.

Altering the query as per this PR to an `INNER JOIN` makes the query return in 1s 🎉 . Attached are the query analyze results for the existing left join and new inner join style.

AFAICT The function in Nelson expects a list of status to be provided, so it doesn't make sense to query for deployments without a status (with LEFT JOIN) as _something_ must always be supplied by the user, and thus using an INNER JOIN allows the database to pre-emptively filter those records.

[new-innerjoin.log](https://github.com/getnelson/nelson/files/4952130/new-innerjoin.log)
[old-leftjoin.log](https://github.com/getnelson/nelson/files/4952131/old-leftjoin.log)
