### PR TITLE
Upgrade sbt-protoc dependency

### DIFF
--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.1"


### PR DESCRIPTION
It appears this version of the plugin needed updating as CI was failing to download it. 